### PR TITLE
Do not check server URL

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -85,7 +85,7 @@ class ERDDAP(object):
     def __init__(self, server, protocol=None, response="html"):
         if server in servers.keys():
             server = servers[server].url
-        self.server = _check_url_response(server)
+        self.server = server
         self.protocol = protocol
 
         # Initialized only via properties.


### PR DESCRIPTION
While it is nice to fail early some servers re-direct and this check may lead to a bogus failure. Also, we do check all endpoints created, so there is no need for the root to be checked.