### PR TITLE
Publish to PyPI when building the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,4 +85,4 @@ deploy:
     repo: ioos/erddapy
     tags: true
     all_branches: master
-    condition: '$TEST_TARGET == "default"'
+    condition: '$TEST_TARGET == "docs"'


### PR DESCRIPTION
We no longer have a `default` travis job.