### PR TITLE
add setuptools_scm to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=41.2", "wheel"]
+requires = ["setuptools>=41.2", "setuptools_scm", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We need `setuptools_scm` at build time.