### PR TITLE
Nc response

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ isort
 jupyter
 mypy
 nbsphinx
+netcdf4
 pendulum>=2.0.1
 pre-commit
 pylint


### PR DESCRIPTION
@gmaze this is still a work in progress but it may help you in `argopy`. All methods that uses the netCDF response will use in memory whenever it is possible.

I'm still investigating how to integrate this with `fsspec` and possible lazy loads of netCDF files.