### PR TITLE
Fix mandatory dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas >=0.20.3
+pytz
 requests


### PR DESCRIPTION
`pytz` is a main dependency that was not specified.