### PR TITLE
Raise for status and 'promote' check URL

### DIFF
--- a/erddapy/utilities.py
+++ b/erddapy/utilities.py
@@ -55,12 +55,18 @@ def urlopen(url, auth: Optional[tuple] = None) -> BinaryIO:
 
     """
     response = requests.get(url, allow_redirects=True, auth=auth)
+    response.raise_for_status()
     return io.BytesIO(response.content)
 
 
 @functools.lru_cache(maxsize=None)
-def _check_url_response(url: str, **kwargs: Dict) -> str:
-    """Shortcut to `raise_for_status` instead of fetching the whole content."""
+def check_url_response(url: str, **kwargs: Dict) -> str:
+    """
+    Shortcut to `raise_for_status` instead of fetching the whole content.
+    One should only use this is passing URLs that are known to work is necessary.
+    Otherwise let it fail later and avoid fetching the head.
+
+    """
     r = requests.head(url, **kwargs)
     r.raise_for_status()
     return url

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -3,7 +3,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from erddapy import ERDDAP
-from erddapy.utilities import _check_url_response, parse_dates
+from erddapy.utilities import check_url_response, parse_dates
 
 
 def _url_to_dict(url):
@@ -43,7 +43,7 @@ def test_search_url_bad_request(e):
         "max_time": "1750-01-01T12:00:00Z",
     }
     with pytest.raises(HTTPError):
-        _check_url_response(e.get_search_url(**kw))
+        check_url_response(e.get_search_url(**kw))
 
 
 @pytest.mark.web

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -10,9 +10,9 @@ import pytz
 from requests.exceptions import HTTPError
 
 from erddapy.utilities import (
-    _check_url_response,
     _clean_response,
     _tempnc,
+    check_url_response,
     parse_dates,
     quote_string_constraints,
     servers,
@@ -25,7 +25,7 @@ from erddapy.utilities import (
 def test_servers():
     for server in servers.values():
         # Should raise HTTPError if broken, otherwise returns the URL.
-        _check_url_response(server.url) == server.url
+        check_url_response(server.url) == server.url
 
 
 @pytest.mark.web
@@ -37,7 +37,15 @@ def test_urlopen():
 
 
 @pytest.mark.web
-def test__check_url_response():
+def test_urlopen_raise():
+    """Assure that urlopen will raise for bad URLs."""
+    url = "https://developer.mozilla.org/en-US/404"
+    with pytest.raises(HTTPError):
+        urlopen(url)
+
+
+@pytest.mark.web
+def test_check_url_response():
     """Test if a bad request returns HTTPError."""
     bad_request = (
         "http://erddap.sensors.ioos.us/erddap/tabledap/"
@@ -47,7 +55,7 @@ def test__check_url_response():
         "&time<=2015-09-05T19:00:00Z"
     )
     with pytest.raises(HTTPError):
-        _check_url_response(bad_request)
+        check_url_response(bad_request)
 
 
 def test__clean_response():


### PR DESCRIPTION
`check_url_response` should be part of the public API and `urlopen` raises for status before returning bad data.