### PR TITLE
add more files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ build/
 dist/
 docs/source/quick_intro.ipynb
 docs/source/searchfor.ipynb
-notebooks/quick_intro-output.ipynb
+notebooks/*-output.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 .ipynb_checkpoints
 .mypy_cache/
 .pytest_cache/
+_version.py
 build/
 dist/
 docs/source/quick_intro.ipynb
 docs/source/searchfor.ipynb
+notebooks/quick_intro-output.ipynb


### PR DESCRIPTION
`_version.py` is managed by `setuptools_scm` and we don't want to commit notebooks with outputs anymore.