### PR TITLE
Re-adds the ability to pass requests_kwargs to underlying request

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Bugfix: return ability to pass keyword arguments to `requests.get`.
+
 ## 0.6.0
 
 - Added the `distinct()` server-side function

--- a/erddapy/utilities.py
+++ b/erddapy/utilities.py
@@ -25,11 +25,11 @@ except ImportError:
     from pandas._libs.tslibs.parsing import parse_time_string
 
 
-def _nc_dataset(url, auth):
+def _nc_dataset(url, auth, **requests_kwargs: Dict):
     """Returns a netCDF4-python Dataset from memory and fallbacks to disk if that fails."""
     from netCDF4 import Dataset
 
-    data = urlopen(url=url, auth=auth)
+    data = urlopen(url=url, auth=auth, **requests_kwargs)
     try:
         return Dataset(Path(urlparse(url).path).name, memory=data.read())
     except OSError:
@@ -53,13 +53,13 @@ def servers_list():
 servers = servers_list()
 
 
-def urlopen(url, auth: Optional[tuple] = None) -> BinaryIO:
+def urlopen(url, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO:
     """Thin wrapper around requests get content.
 
     See requests.get docs for the `params` and `kwargs` options.
 
     """
-    response = requests.get(url, allow_redirects=True, auth=auth)
+    response = requests.get(url, allow_redirects=True, auth=auth, **kwargs)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -1,0 +1,29 @@
+import pytest
+from requests.exceptions import ReadTimeout
+
+from erddapy import ERDDAP
+
+
+@pytest.mark.web
+def test_erddap_requests_kwargs():
+    """ Test that an ERDDAP instance can have requests_kwargs attribute assigned
+    and are passed to the underlying methods """
+
+    base_url = "http://www.neracoos.org/erddap"
+    timeout_seconds = 1  # request timeout in seconds
+    slowwly_milliseconds = (timeout_seconds + 1) * 1000
+    slowwly_url = (
+        "http://slowwly.robertomurray.co.uk/delay/"
+        + str(slowwly_milliseconds)
+        + "/url/"
+        + base_url
+    )
+
+    connection = ERDDAP(slowwly_url)
+    connection.dataset_id = "M01_sbe37_all"
+    connection.protocol = "tabledap"
+
+    connection.requests_kwargs["timeout"] = timeout_seconds
+
+    with pytest.raises(ReadTimeout):
+        ds = connection.to_xarray()

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -1,4 +1,5 @@
 import pytest
+
 from requests.exceptions import ReadTimeout
 
 from erddapy import ERDDAP
@@ -26,4 +27,4 @@ def test_erddap_requests_kwargs():
     connection.requests_kwargs["timeout"] = timeout_seconds
 
     with pytest.raises(ReadTimeout):
-        ds = connection.to_xarray()
+        connection.to_xarray()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -7,7 +7,7 @@ import pendulum
 import pytest
 import pytz
 
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ReadTimeout
 
 from erddapy.utilities import (
     _clean_response,
@@ -42,6 +42,23 @@ def test_urlopen_raise():
     url = "https://developer.mozilla.org/en-US/404"
     with pytest.raises(HTTPError):
         urlopen(url)
+
+
+@pytest.mark.web
+def test_urlopen_requests_kwargs():
+    """ Test that urlopen can pass kwargs to requests """
+    base_url = "http://erddap.sensors.ioos.us/erddap/tabledap/"
+    timeout_seconds = 1  # request timeout in seconds
+    slowwly_milliseconds = (timeout_seconds + 1) * 1000
+    slowwly_url = (
+        "http://slowwly.robertomurray.co.uk/delay/"
+        + str(slowwly_milliseconds)
+        + "/url/"
+        + base_url
+    )
+
+    with pytest.raises(ReadTimeout):
+        urlopen(slowwly_url, timeout=timeout_seconds)
 
 
 @pytest.mark.web


### PR DESCRIPTION
Adds several tests to make sure that keyword arguments can be passed appropriately
to requests.get, including simulating passing a timeout and querying through
a slow proxy.

Does not work on the removed request params, as that may be mixed in with auth.

Closes #131