### PR TITLE
Do not run tests on artifact publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test wheels
       run: |
-        cd dist && python -m pip install erddapy*.whl && python -m pytest --pyargs erddapy
+        cd dist && python -m pip install erddapy*.whl
         python -m twine check *
       shell: bash
 


### PR DESCRIPTION
We don't ship the tests with the source distribution.