### PR TITLE
Feature/server functions

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -134,6 +134,7 @@ class ERDDAP:
 
         # Initialized only via properties.
         self.constraints: Optional[Dict] = None
+        self.relative_constraints: Optional[Dict] = None
         self.server_functions: Optional[Dict] = None
         self.dataset_id: OptionalStr = None
         self.requests_kwargs: Dict = {}
@@ -352,7 +353,7 @@ class ERDDAP:
         variables = variables if variables else self.variables
         response = response if response else self.response
         constraints = constraints if constraints else self.constraints
-        relative_constraints = relative_constraints if relative_constraints else self.server_functions
+        relative_constraints = relative_constraints if relative_constraints else self.relative_constraints
         
         if not dataset_id:
             raise ValueError(f"Please specify a valid `dataset_id`, got {dataset_id}")

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -134,6 +134,7 @@ class ERDDAP:
 
         # Initialized only via properties.
         self.constraints: Optional[Dict] = None
+        self.server_functions: Optional[Dict] = None
         self.dataset_id: OptionalStr = None
         self.requests_kwargs: Dict = {}
         self.auth: Optional[tuple] = None
@@ -318,6 +319,7 @@ class ERDDAP:
         variables: Optional[ListLike] = None,
         response=None,
         constraints=None,
+        relative_constraints=None,
         **kwargs,
     ) -> str:
         """The download URL for the `server` endpoint.
@@ -335,6 +337,12 @@ class ERDDAP:
                                     'time<=': '2017-02-10T00:00:00+00:00',
                                     'time>=': '2016-07-10T00:00:00+00:00',}
 
+            relative_constraints (dict): advanced download constraints , default None
+            example: relative_constraints = {'time>': 'now-7days',
+                                         'latitude<':'min(longitude)+180'
+                                         'depth>':'max(depth)-23'
+                                            }
+
         Returns:
             url (str): the download URL for the `response` chosen.
 
@@ -344,7 +352,8 @@ class ERDDAP:
         variables = variables if variables else self.variables
         response = response if response else self.response
         constraints = constraints if constraints else self.constraints
-
+        relative_constraints = relative_constraints if relative_constraints else self.server_functions
+        
         if not dataset_id:
             raise ValueError(f"Please specify a valid `dataset_id`, got {dataset_id}")
 
@@ -370,6 +379,13 @@ class ERDDAP:
             _constraints = "".join([f"&{k}{v}" for k, v in _constraints.items()])
 
             url += f"{_constraints}"
+
+        if relative_constraints:
+            _relative_constraints = "".join([f"&{k}{v}" for k, v in relative_constraints.items()])
+            url += f"{_relative_constraints}"
+
+
+
         url = _distinct(url, **kwargs)
         return url
 

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -71,6 +71,7 @@ class ERDDAP:
         variables: a list variables to download.
         response: default is HTML.
         constraints: download constraints, default None (opendap-like url)
+        relative_constraints: download constraints based on ERDDAP server calulations, default None
         params and requests_kwargs: `request.get` options
 
     Returns:

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -71,7 +71,7 @@ class ERDDAP:
         variables: a list variables to download.
         response: default is HTML.
         constraints: download constraints, default None (opendap-like url)
-        relative_constraints: download constraints based on ERDDAP server calulations, default None
+        relative_constraints: download constraints based on ERDDAP server calculations, default None
         params and requests_kwargs: `request.get` options
 
     Returns:
@@ -354,8 +354,10 @@ class ERDDAP:
         variables = variables if variables else self.variables
         response = response if response else self.response
         constraints = constraints if constraints else self.constraints
-        relative_constraints = relative_constraints if relative_constraints else self.relative_constraints
-        
+        relative_constraints = (
+            relative_constraints if relative_constraints else self.relative_constraints
+        )
+
         if not dataset_id:
             raise ValueError(f"Please specify a valid `dataset_id`, got {dataset_id}")
 
@@ -383,10 +385,10 @@ class ERDDAP:
             url += f"{_constraints}"
 
         if relative_constraints:
-            _relative_constraints = "".join([f"&{k}{v}" for k, v in relative_constraints.items()])
+            _relative_constraints = "".join(
+                [f"&{k}{v}" for k, v in relative_constraints.items()],
+            )
             url += f"{_relative_constraints}"
-
-
 
         url = _distinct(url, **kwargs)
         return url

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -194,14 +194,14 @@ def test_download_url_distinct(e):
 
 # Test generic sever-side functions
 def test_download_url_server_functions(e):
-    """Check download URL results with and without the distinct option."""
+    """Check download URL results with and without the relative constraint option."""
     dataset_id = "gtoppAT"
     variables = ["commonName", "yearDeployed", "serialNumber"]
-    no_distinct_url = e.get_download_url(dataset_id=dataset_id, variables=variables)
-    with_distinct_url = e.get_download_url(
+    no_relative_constraints_url = e.get_download_url(dataset_id=dataset_id, variables=variables)
+    with_relative_constraints_url = e.get_download_url(
         dataset_id=dataset_id,
         variables=variables,
         relative_constraints={"time=": "max(time)+0minutes"},
     )
-    assert not no_distinct_url.endswith("&time=max(time)+0minutes")
-    assert with_distinct_url.endswith("&time=max(time)+0minutes")
+    assert not no_relative_constraints_url.endswith("&time=max(time)+0minutes")
+    assert with_relative_constraints_url.endswith("&time=max(time)+0minutes")

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -192,12 +192,16 @@ def test_download_url_distinct(e):
     assert not no_distinct_url.endswith("&distinct()")
     assert with_distinct_url.endswith("&distinct()")
 
+
 # Test generic sever-side functions
 def test_download_url_server_functions(e):
     """Check download URL results with and without the relative constraint option."""
     dataset_id = "gtoppAT"
     variables = ["commonName", "yearDeployed", "serialNumber"]
-    no_relative_constraints_url = e.get_download_url(dataset_id=dataset_id, variables=variables)
+    no_relative_constraints_url = e.get_download_url(
+        dataset_id=dataset_id,
+        variables=variables,
+    )
     with_relative_constraints_url = e.get_download_url(
         dataset_id=dataset_id,
         variables=variables,

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -191,3 +191,17 @@ def test_download_url_distinct(e):
     )
     assert not no_distinct_url.endswith("&distinct()")
     assert with_distinct_url.endswith("&distinct()")
+
+# Test generic sever-side functions
+def test_download_url_server_functions(e):
+    """Check download URL results with and without the distinct option."""
+    dataset_id = "gtoppAT"
+    variables = ["commonName", "yearDeployed", "serialNumber"]
+    no_distinct_url = e.get_download_url(dataset_id=dataset_id, variables=variables)
+    with_distinct_url = e.get_download_url(
+        dataset_id=dataset_id,
+        variables=variables,
+        relative_constraints={"time=": "max(time)+0minutes"},
+    )
+    assert not no_distinct_url.endswith("&time=max(time)+0minutes")
+    assert with_distinct_url.endswith("&time=max(time)+0minutes")


### PR DESCRIPTION
Changes to allow the use of server side functions within the URL parameters as built up from within erddapy

as mentioned in #161

This will work across any URL parameter time or otherwise. After looking over the code it was felt best to add in a new attribute within the erddap class modelled on constraints, thus skipping the need for complex string/time checks and if statements.

