### PR TITLE
Improve docstring for `get_categorize_url()` function

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -306,7 +306,7 @@ class ERDDAP:
 
         Args:
             categorize_by: a valid attribute, e.g.: ioos_category or standard_name.
-                Valid attributes are shown in the '<YOUR-ERDDAP-URL>/erddap/categorize' page.
+                Valid attributes are shown in the https://coastwatch.pfeg.noaa.gov/erddap/categorize page.
             value: an attribute value.
             response: default is HTML.
 

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -306,6 +306,7 @@ class ERDDAP:
 
         Args:
             categorize_by: a valid attribute, e.g.: ioos_category or standard_name.
+                Valid attributes are shown in the '<YOUR-ERDDAP-URL>/erddap/categorize' page.
             value: an attribute value.
             response: default is HTML.
 


### PR DESCRIPTION
Hi,

As an ERDDAP beginner, I was having some trouble discovering what are valid attributes to categorize by. After realising that I could find them at the `erddap/categorize/index.html` page, I decided to improve the `get_categorize_url()` docstring for other users that may run into the same problem.

Summary of changes:
  - In `get_categorize_url()` function: Add a line to the docstring explaining that valid attributes can be found in the categorize page.

Best,
Vini