### PR TITLE
fix github dependency graph issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 
 setup(
+    # The package metadata is specified in setup.cfg but GitHub's downstream dependency graph
+    # does not work unless we put the name this here too.
+    name="erddapy",
     use_scm_version={
         "write_to": "erddapy/_version.py",
         "write_to_template": '__version__ = "{version}"',


### PR DESCRIPTION
GitHub dependency graph only works if the name metadata is here.