### PR TITLE
remove unused code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         - --quiet-level=2
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.28.0
+  rev: v2.29.0
   hooks:
     - id: pyupgrade
       args:

--- a/erddapy/url_handling.py
+++ b/erddapy/url_handling.py
@@ -46,15 +46,6 @@ def check_url_response(url: str, **kwargs: Dict) -> str:
     return url
 
 
-def _clean_response(response: str) -> str:
-    """Allow for `ext` or `.ext` format.
-
-    The user can, for example, use either `.csv` or `csv` in the response kwarg.
-
-    """
-    return response.lstrip(".")
-
-
 def _distinct(url: str, **kwargs: Dict) -> str:
     """
     Sort all of the rows in the results table

--- a/tests/test_url_handling.py
+++ b/tests/test_url_handling.py
@@ -3,7 +3,7 @@ import io
 import pytest
 from requests.exceptions import HTTPError, ReadTimeout
 
-from erddapy.url_handling import _clean_response, check_url_response, urlopen
+from erddapy.url_handling import check_url_response, urlopen
 
 
 @pytest.mark.web

--- a/tests/test_url_handling.py
+++ b/tests/test_url_handling.py
@@ -51,8 +51,3 @@ def test_check_url_response():
     )
     with pytest.raises(HTTPError):
         check_url_response(bad_request)
-
-
-def test__clean_response():
-    """Test if users can pass responses with or without the '.'."""
-    assert _clean_response("html") == _clean_response(".html")


### PR DESCRIPTION
This was a bad idea from the start. Users should not have an option of using an extension instead of a response code as args. We are already not using it for a while, so removing this should be harmless.