### PR TITLE
Remove Pandas FutureWarning

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -101,17 +101,16 @@ def _griddap_get_constraints(
             data_start = data[-1][0]
         else:
             data_start = data[0][0]
-        table = table.append(
-            {
+        table = pd.concat([
+            table,
+            pd.DataFrame([{
                 "dimension name": dim,
                 "min": data_start,
                 "max": data[-1][0],
                 "length": len(data),
-            },
-            ignore_index=True,
+            }])],
         )
-    table.index = table["dimension name"]
-    table = table.drop("dimension name", axis=1)
+    table.set_index("dimension name", drop=True)
     constraints_dict = {}
     for dim, data in table.iterrows():
         constraints_dict[f"{dim}>="] = data["min"]

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -101,21 +101,18 @@ def _griddap_get_constraints(
             data_start = data[-1][0]
         else:
             data_start = data[0][0]
-        table = pd.concat(
+
+        meta = pd.DataFrame(
             [
-                table,
-                pd.DataFrame(
-                    [
-                        {
-                            "dimension name": dim,
-                            "min": data_start,
-                            "max": data[-1][0],
-                            "length": len(data),
-                        },
-                    ],
-                ),
+                {
+                    "dimension name": dim,
+                    "min": data_start,
+                    "max": data[-1][0],
+                    "length": len(data),
+                },
             ],
         )
+        table = pd.concat([table, meta])
     table = table.set_index("dimension name", drop=True)
     constraints_dict = {}
     for dim, data in table.iterrows():

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -101,14 +101,20 @@ def _griddap_get_constraints(
             data_start = data[-1][0]
         else:
             data_start = data[0][0]
-        table = pd.concat([
-            table,
-            pd.DataFrame([{
-                "dimension name": dim,
-                "min": data_start,
-                "max": data[-1][0],
-                "length": len(data),
-            }])],
+        table = pd.concat(
+            [
+                table,
+                pd.DataFrame(
+                    [
+                        {
+                            "dimension name": dim,
+                            "min": data_start,
+                            "max": data[-1][0],
+                            "length": len(data),
+                        },
+                    ],
+                ),
+            ],
         )
     table.set_index("dimension name", drop=True)
     constraints_dict = {}

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -116,7 +116,7 @@ def _griddap_get_constraints(
                 ),
             ],
         )
-    table.set_index("dimension name", drop=True)
+    table = table.set_index("dimension name", drop=True)
     constraints_dict = {}
     for dim, data in table.iterrows():
         constraints_dict[f"{dim}>="] = data["min"]


### PR DESCRIPTION
Hi,

### Problem
When running `ERDDAP.griddap_initialize`, I would get the following warning: `FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.` My Pandas version is 1.4.0.

### Proposed solution
If merged, this PR will modify the `_griddap_get_constraints` function in order to remove the Pandas FutureWarning that was introduced in the latest Pandas versions.

I ran Pytest, Pre-Commit, and tested the function locally (by running `ERDDAP.griddap_initialize`), and things seem to be working properly.

Summary of changes:
* Replace `frame.append()` with `pd.concat()`
* Replace `table.index =` with `.set_index(drop=True)`
* Format code with Black

Thank you for any assistance you can provide,

Vini