### PR TITLE
cache _griddap_get_constraints result

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -70,6 +70,7 @@ def parse_dates(date_time: Union[datetime, str]) -> float:
     return parse_date_time.timestamp()
 
 
+@functools.lru_cache(maxsize=256)
 def _griddap_get_constraints(
     dataset_url: str,
     step: int,


### PR DESCRIPTION
This operation can be quite slow and we should cache it to re-use when the inputs do not change.
We should also prepare an override option when the user knows all the constraints.