### PR TITLE
drop py36 and pandas <1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,18 +19,19 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 
 [options]
 zip_safe = True
 include_package_data = True
 install_requires =
-    pandas >=0.20.3
+    pandas >=1
     requests
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 
 [sdist]


### PR DESCRIPTION
At some point we should probably vendor `parse_time_string` b/c that is not part of pandas' public API.