### PR TITLE
Suggest running pip as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ conda install --channel conda-forge erddapy
 or, if you are a `pip` users
 
 ```shell
-pip install erddapy
+python -m pip install erddapy
 ```
 
 Note that, if you are installing the `requirements-dev.txt`, the `iris` package


### PR DESCRIPTION
Suggest that when doing a pip install, use `python -m pip install erddapy` to make sure that the pip is correct for the Python install.

xref: #242