### PR TITLE
Use lazy loading when response type is OPeNDAP

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -606,10 +606,14 @@ class ERDDAP:
         """
         import xarray as xr
 
-        response = "nc" if self.protocol == "griddap" else "ncCF"
-        url = self.get_download_url(response=response)
-        nc = _nc_dataset(url, auth=self.auth, **self.requests_kwargs)
-        return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **kw)
+        if self.response == "opendap":
+            url = self.get_download_url()
+            return xr.open_dataset(url, **kw)
+        else:
+            response = "nc" if self.protocol == "griddap" else "ncCF"
+            url = self.get_download_url(response=response)
+            nc = _nc_dataset(url, auth=self.auth, **self.requests_kwargs)
+            return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **kw)
 
     def to_iris(self, **kw):
         """Load the data request into an iris.CubeList.

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -39,6 +39,14 @@ def dataset_griddap(neracoos):
 
 
 @pytest.fixture
+def dataset_opendap():
+    """Load griddap data with OPeNDAP response for testing."""
+    cswc = ERDDAP(server="CSWC", protocol="griddap", response="opendap")
+    cswc.dataset_id = "jplAquariusSSS3MonthV5"
+    yield cswc
+
+
+@pytest.fixture
 def dataset_tabledap(sensors):
     """Load tabledap for testing."""
     sensors.dataset_id = "osmc_23091"
@@ -84,6 +92,13 @@ def test_to_xarray_tabledap(dataset_tabledap):
 def test_to_xarray_griddap(dataset_griddap):
     """Test converting griddap to an xarray Dataset."""
     ds = dataset_griddap.to_xarray()
+    assert isinstance(ds, xr.Dataset)
+
+
+@pytest.mark.web
+def test_to_xarray_opendap(dataset_opendap):
+    """Test converting griddap to an xarray Dataset, use lazy loading for OPeNDAP response."""
+    ds = dataset_opendap.to_xarray()
     assert isinstance(ds, xr.Dataset)
 
 


### PR DESCRIPTION
Hi,

this closes #250.

**Summary of changes**
- On method `ERDDAP.to_xarray`, check if response type is opendap. If it is, pass the URL to the `xarray.open_dataset` method instead of an nc dataset. This allows lazy loading of the dataset.
- Add corresponding tests (based on the `01a-griddap` notebook).

Please feel free to request any changes.

Thank you,
Vini