### PR TITLE
Refactor test 'test_to_xarray_opendap'

### DIFF
--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -39,11 +39,12 @@ def dataset_griddap(neracoos):
 
 
 @pytest.fixture
-def dataset_opendap():
+def dataset_opendap(neracoos):
     """Load griddap data with OPeNDAP response for testing."""
-    cswc = ERDDAP(server="CSWC", protocol="griddap", response="opendap")
-    cswc.dataset_id = "jplAquariusSSS3MonthV5"
-    yield cswc
+    neracoos.dataset_id = "WW3_EastCoast_latest"
+    neracoos.protocol = "griddap"
+    neracoos.response = "opendap"
+    yield neracoos
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi,

this is a follow-up to the discussion in #252. I got the test to work with the NERACOOS server. But there's a catch: the OPeNDAP request seems to fail after running the `griddap_initialize` method. My impression is that happens because that when that method is called, it adds the dataset bounds to the download URL, and the `xarray.open_dataset` method doesn't handle that well. I will look into that soon.

**Summary of changes**
  - Refactor test to use NERACOOS WW3_EastCoast_latest dataset
  - Modify fixture 'dataset_opendap'

Please feel free to request any changes.

Thank you,
Vini