### PR TITLE
Increase number per items on CSV, JSON searches

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -74,8 +74,7 @@ def _griddap_get_constraints(
     """
     Fetch metadata of griddap dataset and set initial constraints.
 
-    Step size is applied to all dimensions
-
+    Step size is applied to all dimensions.
     """
     dds_url = f"{dataset_url}.dds"
     url = urlopen(dds_url)
@@ -399,8 +398,10 @@ class ERDDAP:
         protocol = protocol if protocol else self.protocol
         response = response if response else self.response
 
-        # Different protocol if not dealing with pagination, return all records.
-        # This is done for all CSV, JSON and TSV-style responses.
+        # These responses should not be paginated b/c that hinders the correct amount of data silently
+        # and can surprise users when the number of items is greater than ERDDAP's defaults (1000 items).
+        # Ideally there should be no pagination for this on the ERDDAP side but for now we settled for a
+        # "really big" `items_per_page` number.
         non_paginated_responses = [
             "csv",
             "csvp",

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -385,7 +385,7 @@ class ERDDAP:
 
             response: default is HTML.
             items_per_page: how many items per page in the return,
-                default is 1000.
+                default is 1000 for HTML, 1e6 (hopefully all items) for CSV, JSON.
             page: which page to display, default is the first page (1).
             kwargs: extra search constraints based on metadata and/or coordinates ke/value.
                 metadata: `cdm_data_type`, `institution`, `ioos_category`,
@@ -398,6 +398,12 @@ class ERDDAP:
         """
         protocol = protocol if protocol else self.protocol
         response = response if response else self.response
+
+        # Different protocol if not dealing with pagination, return all records
+        non_paginated_responses = ["csv", "json"]
+        if response in non_paginated_responses:
+            items_per_page = int(1e6)
+
         return _search_url(
             self.server,
             response=response,

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -399,8 +399,20 @@ class ERDDAP:
         protocol = protocol if protocol else self.protocol
         response = response if response else self.response
 
-        # Different protocol if not dealing with pagination, return all records
-        non_paginated_responses = ["csv", "json"]
+        # Different protocol if not dealing with pagination, return all records.
+        # This is done for all CSV, JSON and TSV-style responses.
+        non_paginated_responses = [
+            "csv",
+            "csvp",
+            "csv0",
+            "json",
+            "jsonlCSV1",
+            "jsonlCSV",
+            "jsonlKVP",
+            "tsv",
+            "tsvp",
+            "tsv0",
+        ]
         if response in non_paginated_responses:
             items_per_page = int(1e6)
 

--- a/tests/cassettes/test_erddap2_10.yaml
+++ b/tests/cassettes/test_erddap2_10.yaml
@@ -45,4 +45,50 @@ interactions:
       - Origin
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - erddap.ioos.us
+      user-agent:
+      - python-httpx/0.23.0
+    method: HEAD
+    uri: http://erddap.ioos.us/erddap/search/advanced.csv?page=1&itemsPerPage=1000000&protocol=(ANY)&cdm_data_type=(ANY)&institution=(ANY)&ioos_category=(ANY)&keywords=(ANY)&long_name=(ANY)&standard_name=(ANY)&variableName=(ANY)&minLon=(ANY)&maxLon=(ANY)&minLat=(ANY)&maxLat=(ANY)&minTime=&maxTime=&searchFor=NOAA
+  response:
+    content: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment;filename=AdvancedSearch.csv
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3960'
+      Content-Type:
+      - text/csv;charset=ISO-8859-1
+      Date:
+      - Thu, 28 Jul 2022 15:33:50 GMT
+      Keep-Alive:
+      - timeout=20
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      vary:
+      - Origin
+    http_version: HTTP/1.1
+    status_code: 200
 version: 1

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -76,7 +76,6 @@ def dataset_tabledap(sensors):
 
 
 @pytest.mark.web
-@pytest.mark.vcr()
 def test_csv_search(gliders):
     """Test if a CSV search returns all items (instead of the first 1000)."""
     # The gliders server has 1244 datasets at time of writing
@@ -87,7 +86,6 @@ def test_csv_search(gliders):
 
 
 @pytest.mark.web
-@pytest.mark.vcr()
 def test_json_search(gliders):
     """Test if a JSON search returns all items (instead of the first 1000)."""
     # The gliders server has 1244 datasets at time of writing

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -2,6 +2,7 @@
 
 import sys
 
+import httpx
 import iris
 import pytest
 import xarray as xr
@@ -15,6 +16,16 @@ def sensors():
     """Instantiate ERDDAP class for testing."""
     yield ERDDAP(
         server="https://erddap.sensors.ioos.us/erddap/",
+        response="htmlTable",
+    )
+
+
+@pytest.fixture
+@pytest.mark.web
+def gliders():
+    """Instantiate ERDDAP class for testing."""
+    yield ERDDAP(
+        server="https://gliders.ioos.us/erddap/",
         response="htmlTable",
     )
 
@@ -62,6 +73,28 @@ def dataset_tabledap(sensors):
         "longitude<=": 90,
     }
     yield sensors
+
+
+@pytest.mark.web
+@pytest.mark.vcr()
+def test_csv_search(gliders):
+    """Test if a CSV search returns all items (instead of the first 1000)."""
+    # The gliders server has 1244 datasets at time of writing
+    url = gliders.get_search_url(search_for="all", response="csv")
+    handle = httpx.get(url)
+    nrows = len(list(handle.iter_lines())) - 1
+    assert nrows > 1000
+
+
+@pytest.mark.web
+@pytest.mark.vcr()
+def test_json_search(gliders):
+    """Test if a JSON search returns all items (instead of the first 1000)."""
+    # The gliders server has 1244 datasets at time of writing
+    url = gliders.get_search_url(search_for="all", response="json")
+    handle = httpx.get(url)
+    nrows = len(handle.json()["table"]["rows"])
+    assert nrows > 1000
 
 
 @pytest.mark.web

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -24,6 +24,7 @@ def sensors():
 @pytest.mark.web
 def gliders():
     """Instantiate ERDDAP class for testing."""
+    # The gliders server has 1244 datasets at time of writing
     yield ERDDAP(
         server="https://gliders.ioos.us/erddap/",
         response="htmlTable",
@@ -78,7 +79,6 @@ def dataset_tabledap(sensors):
 @pytest.mark.web
 def test_csv_search(gliders):
     """Test if a CSV search returns all items (instead of the first 1000)."""
-    # The gliders server has 1244 datasets at time of writing
     url = gliders.get_search_url(search_for="all", response="csv")
     handle = httpx.get(url)
     nrows = len(list(handle.iter_lines())) - 1
@@ -88,7 +88,6 @@ def test_csv_search(gliders):
 @pytest.mark.web
 def test_json_search(gliders):
     """Test if a JSON search returns all items (instead of the first 1000)."""
-    # The gliders server has 1244 datasets at time of writing
     url = gliders.get_search_url(search_for="all", response="json")
     handle = httpx.get(url)
     nrows = len(handle.json()["table"]["rows"])


### PR DESCRIPTION
Hi,

this is in relation to #244. I wasn't sure of the best way to go about this, so I tried keeping it as simple as possible. Please let me know if there's an obvious way that I'm missing.

What I did was simply to set the number of `items_per_page` to a big number (initially it was `1e9`, but I thought that was excessive?) if the response is either `'csv'` or `'json'`. This doesn't require actually making the request, it just builds the URL. I couldn't find a "number of records" variable in the search response. I suppose I could set the `items_per_page` variable to that, but that would require making the request, and I understand that we just want the URL. Removing the `items_per_page` or `page` variables from the URL didn't make any difference.

To test, I added a fixture for the gliders server, since the other two had less than 1000 records. I did not commit the cassettes since they turned out fairly large, at around 3MB each. Do you have any suggestions on what to do about this?

**Summary of changes**
- Modify variable `items_per_page` if `response` is either `'csv'` or `'json'`
- Add new fixture `gliders` to `test_to_objects.py`
- Add tests `test_csv_search` and `test_json_search`

Please feel free to request any changes, and don't forget to add the `gsoc-2022` label :)

Thank you,
Vini