### PR TITLE
Refactor url methods

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -11,6 +11,8 @@ import httpx
 import pytz
 from pandas._libs.tslibs.parsing import parse_time_string
 
+OptionalStr = Optional[str]
+
 
 @functools.lru_cache(maxsize=256)
 def _urlopen(url: str, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO:
@@ -59,7 +61,7 @@ def _distinct(url: str, **kwargs: Dict) -> str:
     For example, a query for the variables ["stationType", "stationID"] with `distinct=True`
     will return a sorted list of "stationIDs" associated with each "stationType".
 
-    See https://coastwatch.pfeg.noaa.gov/erddap/tabledap/documentation.html#distinct
+    See http://erddap.ioos.us/erddap/tabledap/documentation.html#distinct
 
     """
     distinct = kwargs.pop("distinct", False)
@@ -268,4 +270,53 @@ def get_search_url(
     # ERDDAP 2.10 no longer accepts strings placeholder for dates.
     # Removing them entirely should be OK for older versions too.
     url = url.replace("&minTime=(ANY)", "").replace("&maxTime=(ANY)", "")
+    return url
+
+
+def get_info_url(
+    server: str,
+    dataset_id: OptionalStr = None,
+    response: OptionalStr = None,
+) -> str:
+    """
+    Build the info URL for the `server` endpoint.
+
+    Args:
+        dataset_id: a dataset unique id.
+        response: default is HTML.
+
+    Returns:
+        url: the info URL for the `response` chosen.
+
+    """
+    if not dataset_id:
+        raise ValueError(f"You must specify a valid dataset_id, got {dataset_id}")
+
+    url = f"{server}/info/{dataset_id}/index.{response}"
+    return url
+
+
+def get_categorize_url(
+    server: str,
+    categorize_by: str,
+    value: OptionalStr = None,
+    response: OptionalStr = None,
+) -> str:
+    """
+    Build the categorize URL for the `server` endpoint.
+
+    Args:
+        categorize_by: a valid attribute, e.g.: ioos_category or standard_name.
+            Valid attributes are shown in http://erddap.ioos.us/erddap/categorize page.
+        value: an attribute value.
+        response: default is HTML.
+
+    Returns:
+        url: the categorized URL for the `response` chosen.
+
+    """
+    if value:
+        url = f"{server}/categorize/{categorize_by}/{value}/index.{response}"
+    else:
+        url = f"{server}/categorize/{categorize_by}/index.{response}"
     return url

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -17,7 +17,7 @@ from erddapy.core.url import (
     _distinct,
     _format_constraints_url,
     _quote_string_constraints,
-    _search_url,
+    get_search_url,
     parse_dates,
     urlopen,
 )
@@ -196,26 +196,7 @@ class ERDDAP:
         protocol = protocol if protocol else self.protocol
         response = response if response else self.response
 
-        # These responses should not be paginated b/c that hinders the correct amount of data silently
-        # and can surprise users when the number of items is greater than ERDDAP's defaults (1000 items).
-        # Ideally there should be no pagination for this on the ERDDAP side but for now we settled for a
-        # "really big" `items_per_page` number.
-        non_paginated_responses = [
-            "csv",
-            "csvp",
-            "csv0",
-            "json",
-            "jsonlCSV1",
-            "jsonlCSV",
-            "jsonlKVP",
-            "tsv",
-            "tsvp",
-            "tsv0",
-        ]
-        if response in non_paginated_responses:
-            items_per_page = int(1e6)
-
-        return _search_url(
+        return get_search_url(
             self.server,
             response=response,
             search_for=search_for,

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -17,6 +17,8 @@ from erddapy.core.url import (
     _distinct,
     _format_constraints_url,
     _quote_string_constraints,
+    get_categorize_url,
+    get_info_url,
     get_search_url,
     parse_dates,
     urlopen,
@@ -225,11 +227,7 @@ class ERDDAP:
         dataset_id = dataset_id if dataset_id else self.dataset_id
         response = response if response else self.response
 
-        if not dataset_id:
-            raise ValueError(f"You must specify a valid dataset_id, got {dataset_id}")
-
-        url = f"{self.server}/info/{dataset_id}/index.{response}"
-        return url
+        return get_info_url(self.server, dataset_id, response)
 
     def get_categorize_url(
         self,
@@ -242,7 +240,7 @@ class ERDDAP:
 
         Args:
             categorize_by: a valid attribute, e.g.: ioos_category or standard_name.
-                Valid attributes are shown in https://coastwatch.pfeg.noaa.gov/erddap/categorize page.
+                Valid attributes are shown in http://erddap.ioos.us/erddap/categorize page.
             value: an attribute value.
             response: default is HTML.
 
@@ -251,11 +249,7 @@ class ERDDAP:
 
         """
         response = response if response else self.response
-        if value:
-            url = f"{self.server}/categorize/{categorize_by}/{value}/index.{response}"
-        else:
-            url = f"{self.server}/categorize/{categorize_by}/index.{response}"
-        return url
+        return get_categorize_url(self.server, categorize_by, value, response)
 
     def get_download_url(
         self,

--- a/erddapy/multiple_server_search.py
+++ b/erddapy/multiple_server_search.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     joblib = False
 
-from erddapy.core.url import _format_search_string, _multi_urlopen, _search_url
+from erddapy.core.url import _format_search_string, _multi_urlopen, get_search_url
 from erddapy.servers.servers import servers
 
 
@@ -112,12 +112,12 @@ def advanced_search_servers(
     response = "csv"
     if servers_list:
         urls = {
-            server: _search_url(server, response=response, **kwargs)
+            server: get_search_url(server, response=response, **kwargs)
             for server in servers_list
         }
     else:
         urls = {
-            key: _search_url(server.url, response=response, **kwargs)
+            key: get_search_url(server.url, response=response, **kwargs)
             for key, server in servers.items()
         }
 

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -7,14 +7,13 @@ import pendulum
 import pytest
 import pytz
 
-from erddapy.erddapy import (
-    ERDDAP,
+from erddapy.core.griddap import _griddap_check_constraints, _griddap_check_variables
+from erddapy.core.url import (
     _format_constraints_url,
-    _griddap_check_constraints,
-    _griddap_check_variables,
     _quote_string_constraints,
     parse_dates,
 )
+from erddapy.erddapy import ERDDAP
 
 
 def test_parse_dates_naive_datetime():

--- a/tests/test_netcdf_handling.py
+++ b/tests/test_netcdf_handling.py
@@ -15,7 +15,7 @@ def test__nc_dataset_in_memory_https():
     """Test loading a netcdf dataset in-memory."""
     from netCDF4 import Dataset
 
-    url = "https://podaac-opendap.jpl.nasa.gov/opendap/allData/modis/L3/aqua/11um/v2019.0/4km/daily/2017/365/AQUA_MODIS.20171231.L3m.DAY.NSST.sst.4km.nc"  # noqa
+    url = "http://erddap.ioos.us/erddap/tabledap/allDatasets.nc"  # noqa
     auth = None
     _nc = _nc_dataset(url, auth)
     assert isinstance(_nc, Dataset)
@@ -26,7 +26,7 @@ def test__nc_dataset_in_memory_https():
 @pytest.mark.vcr()
 def test__tempnc():
     """Test temporary netcdf file."""
-    url = "https://podaac-opendap.jpl.nasa.gov/opendap/allData/modis/L3/aqua/11um/v2019.0/4km/daily/2017/365/AQUA_MODIS.20171231.L3m.DAY.NSST.sst.4km.nc"  # noqa
+    url = "http://erddap.ioos.us/erddap/tabledap/allDatasets.nc"  # noqa
     data = urlopen(url)
     with _tempnc(data) as tmp:
         # Check that the file was exists.

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -3,8 +3,8 @@
 import httpx
 import pytest
 
-from erddapy.core.url import check_url_response
-from erddapy.erddapy import ERDDAP, parse_dates
+from erddapy.core.url import check_url_response, parse_dates
+from erddapy.erddapy import ERDDAP
 
 
 def _url_to_dict(url):


### PR DESCRIPTION
Hi,

this is a downstream branch of #263, so it will be easier to review after merging that and #259. It includes two additional commits that move `get_search_url`, `get_info_url` and `get_categorize_url` from the `erddapy.erddapy` module to the `erddapy.core.url` module.

For `get_download_url`, it's a bit more tricky: it would incur in a circular import between `erddapy.core.url` and the newly-added `erddapy.core.griddap` module, because of the `urlopen` and `_urlopen` functions. So, I'm thinking whether I should move those functions to a new module (maybe `erddapy.core.helpers` or `erddapy.core.__init__`?). Please let me know what you think is best.

Thank you,
Vini

**Summary of changes** (in relation to #263):
- Move the `get_search_url`, `get_info_url`, and `get_categorize_url` to the URL module
- Refactor the private `_search_url` function as public
- Edit docstrings to use gold standard servers