### PR TITLE
Improve exception handling in method to_iris

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
   - cartopy
   - erddapy
-  - iris
+  - iris>=3.3.0
   - jupyter
   - pendulum>=2.0.1
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - erddapy
   - iris>=3.3.0
   - jupyter
+  - netcdf4<1.6.1
   - pendulum>=2.0.1
   - xarray

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -386,7 +386,7 @@ class ERDDAP:
             try:
                 cubes.realise_data()
             except ValueError:
-                iris.cube.CubeList([cube.data for cube in cubes])
+                _ = [cube.data for cube in cubes]
             return cubes
 
     @functools.lru_cache(maxsize=None)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ joblib
 jupyter
 mypy
 nbsphinx
-netcdf4
+netcdf4<1.6.1
 pendulum>=2.0.1
 pooch
 pre-commit


### PR DESCRIPTION
Hi,

this is a fix to the problem mentioned in #267.

On the `ERDDAP.to_iris()` method, when the `cubes.realise_data()` method doesn't work, it realises the data by calling `cube.data`. The new versions of Iris prevent creating a `CubeList` object using `cube.data` objects (as they are Numpy Arrays and not cubes), so that behaviour was modified.

Summary of changes:
  - Realise data by creating placeholder variable `_`
  - Don't use `iris.cube.CubeList` for placeholder variable

Thanks,
Vini