### PR TITLE
Fix kwargs propagation in interfaces module

### DIFF
--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -63,8 +63,7 @@ def to_ncCF(
         )
     if requests_kwargs is None:
         requests_kwargs = {}
-    auth = requests_kwargs.pop("auth", None)
-    return _nc_dataset(url, auth=auth, **requests_kwargs)
+    return _nc_dataset(url, **requests_kwargs)
 
 
 def to_xarray(
@@ -78,18 +77,17 @@ def to_xarray(
 
     url: URL to request data from.
     response: type of response to be requested from the server.
-    requests_kwargs: arguments to be passed to urlopen method.
+    requests_kwargs: arguments to be passed to urlopen method (including auth)
     xarray_kwargs: kwargs to be passed to third-party library (xarray).
     """
     import xarray as xr
 
     if requests_kwargs is None:
         requests_kwargs = {}
-    auth = requests_kwargs.pop("auth", None)
     if response == "opendap":
         return xr.open_dataset(url, **xarray_kwargs)
     else:
-        nc = _nc_dataset(url, auth=auth, **requests_kwargs)
+        nc = _nc_dataset(url, **requests_kwargs)
         return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **xarray_kwargs)
 
 

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -17,35 +17,61 @@ if TYPE_CHECKING:
     import xarray as xr
     from netCDF4 import Dataset
 
+<<<<<<< HEAD
 def to_pandas(url: str, requests_kwargs: Optional[Dict] = None, **kw) -> "pd.DataFrame":
+=======
+def to_pandas(
+    url: str, requests_kwargs: Optional[Dict] = None, **pandas_kwargs
+) -> pd.DataFrame:
+>>>>>>> bf7cbb2 (Renaming **kw according to each library)
     """
     Convert a URL to Pandas DataFrame.
 
     url: URL to request data from.
     requests_kwargs: arguments to be passed to urlopen method.
-    **kw: kwargs to be passed to third-party library (pandas).
+    **pandas_kwargs: kwargs to be passed to third-party library (pandas).
     """
     if requests_kwargs is None:
         requests_kwargs = {}
     data = urlopen(url, **requests_kwargs)
     try:
-        return pd.read_csv(data, **kw)
+        return pd.read_csv(data, **pandas_kwargs)
     except Exception as e:
         raise ValueError(f"Could not read url {url} with Pandas.read_csv.") from e
 
 
+<<<<<<< HEAD
 def to_ncCF(url: str, protocol: str = None, **kw) -> "Dataset":
     """Convert a URL to a netCDF4 Dataset."""
+=======
+def to_ncCF(
+    url: str,
+    protocol: str = None,
+    requests_kwargs: Optional[Dict] = None,
+) -> Dataset:
+    """
+    Convert a URL to a netCDF4 Dataset.
+
+    url: URL to request data from.
+    protocol: 'griddap' or 'tabledap'.
+    requests_kwargs: arguments to be passed to urlopen method (including auth).
+    """
+>>>>>>> bf7cbb2 (Renaming **kw according to each library)
     if protocol == "griddap":
         raise ValueError(
             f"Cannot use .ncCF with griddap protocol. The URL you tried to access is: '{url}'.",
         )
-    auth = kw.pop("auth", None)
-    return _nc_dataset(url, auth=auth, **kw)
+    if requests_kwargs is None:
+        requests_kwargs = {}
+    auth = requests_kwargs.pop("auth", None)
+    return _nc_dataset(url, auth=auth, **requests_kwargs)
 
 
 def to_xarray(
-    url: str, response="opendap", requests_kwargs: Optional[Dict] = None, **kw
+    url: str,
+    response="opendap",
+    requests_kwargs: Optional[Dict] = None,
+    **xarray_kwargs,
 ) -> "xr.Dataset":
     """
     Convert a URL to an xarray dataset.
@@ -53,27 +79,27 @@ def to_xarray(
     url: URL to request data from.
     response: type of response to be requested from the server.
     requests_kwargs: arguments to be passed to urlopen method.
-    **kw: kwargs to be passed to third-party library (xarray).
+    xarray_kwargs: kwargs to be passed to third-party library (xarray).
     """
     import xarray as xr
 
-    auth = kw.pop("auth", None)
+    if requests_kwargs is None:
+        requests_kwargs = {}
+    auth = requests_kwargs.pop("auth", None)
     if response == "opendap":
-        return xr.open_dataset(url, **kw)
+        return xr.open_dataset(url, **xarray_kwargs)
     else:
-        if requests_kwargs is None:
-            requests_kwargs = {}
         nc = _nc_dataset(url, auth=auth, **requests_kwargs)
-        return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **kw)
+        return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **xarray_kwargs)
 
 
-def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **kw):
+def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **iris_kwargs):
     """
     Convert a URL to an iris CubeList.
 
     url: URL to request data from.
     requests_kwargs: arguments to be passed to urlopen method.
-    **kw: kwargs to be passed to third-party library (iris).
+    iris_kwargs: kwargs to be passed to third-party library (iris).
     """
     import iris
 
@@ -81,6 +107,6 @@ def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **kw):
         requests_kwargs = {}
     data = urlopen(url, **requests_kwargs)
     with _tempnc(data) as tmp:
-        cubes = iris.load_raw(tmp, **kw)
+        cubes = iris.load_raw(tmp, **iris_kwargs)
         _ = [cube.data for cube in cubes]
         return cubes

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -28,11 +28,9 @@ def to_pandas(
     requests_kwargs: arguments to be passed to urlopen method.
     **pandas_kwargs: kwargs to be passed to third-party library (pandas).
     """
-    if pandas_kwargs is None:
-        pandas_kwargs = {}
     data = urlopen(url, **(requests_kwargs or {}))
     try:
-        return pd.read_csv(data, **pandas_kwargs)
+        return pd.read_csv(data, **(pandas_kwargs or {}))
     except Exception as e:
         raise ValueError(f"Could not read url {url} with Pandas.read_csv.") from e
 
@@ -72,13 +70,13 @@ def to_xarray(
     """
     import xarray as xr
 
-    if xarray_kwargs is None:
-        xarray_kwargs = {}
     if response == "opendap":
-        return xr.open_dataset(url, **xarray_kwargs)
+        return xr.open_dataset(url, **(xarray_kwargs or {}))
     else:
         nc = _nc_dataset(url, requests_kwargs)
-        return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **xarray_kwargs)
+        return xr.open_dataset(
+            xr.backends.NetCDF4DataStore(nc), **(xarray_kwargs or {})
+        )
 
 
 def to_iris(
@@ -95,10 +93,8 @@ def to_iris(
     """
     import iris
 
-    if iris_kwargs is None:
-        iris_kwargs = {}
     data = urlopen(url, **(requests_kwargs or {}))
     with _tempnc(data) as tmp:
-        cubes = iris.load_raw(tmp, **iris_kwargs)
+        cubes = iris.load_raw(tmp, **(iris_kwargs or {}))
         _ = [cube.data for cube in cubes]
         return cubes

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -17,13 +17,11 @@ if TYPE_CHECKING:
     import xarray as xr
     from netCDF4 import Dataset
 
-<<<<<<< HEAD
-def to_pandas(url: str, requests_kwargs: Optional[Dict] = None, **kw) -> "pd.DataFrame":
-=======
 def to_pandas(
-    url: str, requests_kwargs: Optional[Dict] = None, **pandas_kwargs
-) -> pd.DataFrame:
->>>>>>> bf7cbb2 (Renaming **kw according to each library)
+    url: str,
+    requests_kwargs: Optional[Dict] = None,
+    pandas_kwargs: Optional[Dict] = None,
+) -> "pd.DataFrame":
     """
     Convert a URL to Pandas DataFrame.
 
@@ -33,6 +31,8 @@ def to_pandas(
     """
     if requests_kwargs is None:
         requests_kwargs = {}
+    if pandas_kwargs is None:
+        pandas_kwargs = {}
     data = urlopen(url, **requests_kwargs)
     try:
         return pd.read_csv(data, **pandas_kwargs)
@@ -40,15 +40,11 @@ def to_pandas(
         raise ValueError(f"Could not read url {url} with Pandas.read_csv.") from e
 
 
-<<<<<<< HEAD
-def to_ncCF(url: str, protocol: str = None, **kw) -> "Dataset":
-    """Convert a URL to a netCDF4 Dataset."""
-=======
 def to_ncCF(
     url: str,
     protocol: str = None,
     requests_kwargs: Optional[Dict] = None,
-) -> Dataset:
+) -> "Dataset":
     """
     Convert a URL to a netCDF4 Dataset.
 
@@ -56,7 +52,6 @@ def to_ncCF(
     protocol: 'griddap' or 'tabledap'.
     requests_kwargs: arguments to be passed to urlopen method (including auth).
     """
->>>>>>> bf7cbb2 (Renaming **kw according to each library)
     if protocol == "griddap":
         raise ValueError(
             f"Cannot use .ncCF with griddap protocol. The URL you tried to access is: '{url}'.",
@@ -70,20 +65,22 @@ def to_xarray(
     url: str,
     response="opendap",
     requests_kwargs: Optional[Dict] = None,
-    **xarray_kwargs,
+    xarray_kwargs: Optional[Dict] = None,
 ) -> "xr.Dataset":
     """
     Convert a URL to an xarray dataset.
 
     url: URL to request data from.
     response: type of response to be requested from the server.
-    requests_kwargs: arguments to be passed to urlopen method
+    requests_kwargs: arguments to be passed to urlopen method.
     xarray_kwargs: kwargs to be passed to third-party library (xarray).
     """
     import xarray as xr
 
     if requests_kwargs is None:
         requests_kwargs = {}
+    if xarray_kwargs is None:
+        xarray_kwargs = {}
     if response == "opendap":
         return xr.open_dataset(url, **xarray_kwargs)
     else:
@@ -91,7 +88,11 @@ def to_xarray(
         return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **xarray_kwargs)
 
 
-def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **iris_kwargs):
+def to_iris(
+    url: str,
+    requests_kwargs: Optional[Dict] = None,
+    iris_kwargs: Optional[Dict] = None,
+):
     """
     Convert a URL to an iris CubeList.
 
@@ -103,6 +104,8 @@ def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **iris_kwargs):
 
     if requests_kwargs is None:
         requests_kwargs = {}
+    if iris_kwargs is None:
+        iris_kwargs = {}
     data = urlopen(url, **requests_kwargs)
     with _tempnc(data) as tmp:
         cubes = iris.load_raw(tmp, **iris_kwargs)

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -29,11 +29,9 @@ def to_pandas(
     requests_kwargs: arguments to be passed to urlopen method.
     **pandas_kwargs: kwargs to be passed to third-party library (pandas).
     """
-    if requests_kwargs is None:
-        requests_kwargs = {}
     if pandas_kwargs is None:
         pandas_kwargs = {}
-    data = urlopen(url, requests_kwargs)
+    data = urlopen(url, **(requests_kwargs or {}))
     try:
         return pd.read_csv(data, **pandas_kwargs)
     except Exception as e:
@@ -56,8 +54,6 @@ def to_ncCF(
         raise ValueError(
             f"Cannot use .ncCF with griddap protocol. The URL you tried to access is: '{url}'.",
         )
-    if requests_kwargs is None:
-        requests_kwargs = {}
     return _nc_dataset(url, requests_kwargs)
 
 
@@ -77,8 +73,6 @@ def to_xarray(
     """
     import xarray as xr
 
-    if requests_kwargs is None:
-        requests_kwargs = {}
     if xarray_kwargs is None:
         xarray_kwargs = {}
     if response == "opendap":
@@ -102,11 +96,9 @@ def to_iris(
     """
     import iris
 
-    if requests_kwargs is None:
-        requests_kwargs = {}
     if iris_kwargs is None:
         iris_kwargs = {}
-    data = urlopen(url, requests_kwargs)
+    data = urlopen(url, **(requests_kwargs or {}))
     with _tempnc(data) as tmp:
         cubes = iris.load_raw(tmp, **iris_kwargs)
         _ = [cube.data for cube in cubes]

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -4,9 +4,7 @@ Interface between URL responses and third-party libraries.
 This module takes an URL or the bytes response of a request and converts it to Pandas,
 XArray, Iris, etc. objects.
 """
-from typing import TYPE_CHECKING
-
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import pandas as pd
 
@@ -16,6 +14,7 @@ from erddapy.core.url import urlopen
 if TYPE_CHECKING:
     import xarray as xr
     from netCDF4 import Dataset
+
 
 def to_pandas(
     url: str,

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -6,7 +6,7 @@ XArray, Iris, etc. objects.
 """
 from typing import TYPE_CHECKING
 
-from typing import Dict
+from typing import Dict, Optional
 
 import pandas as pd
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     import xarray as xr
     from netCDF4 import Dataset
 
-def to_pandas(url: str, requests_kwargs: Dict = None, **kw) -> "pd.DataFrame":
+def to_pandas(url: str, requests_kwargs: Optional[Dict] = None, **kw) -> "pd.DataFrame":
     """
     Convert a URL to Pandas DataFrame.
 
@@ -45,7 +45,7 @@ def to_ncCF(url: str, protocol: str = None, **kw) -> "Dataset":
 
 
 def to_xarray(
-    url: str, response="opendap", requests_kwargs: Dict = None, **kw
+    url: str, response="opendap", requests_kwargs: Optional[Dict] = None, **kw
 ) -> "xr.Dataset":
     """
     Convert a URL to an xarray dataset.
@@ -67,7 +67,7 @@ def to_xarray(
         return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **kw)
 
 
-def to_iris(url: str, requests_kwargs: Dict = None, **kw):
+def to_iris(url: str, requests_kwargs: Optional[Dict] = None, **kw):
     """
     Convert a URL to an iris CubeList.
 

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -77,7 +77,7 @@ def to_xarray(
 
     url: URL to request data from.
     response: type of response to be requested from the server.
-    requests_kwargs: arguments to be passed to urlopen method (including auth)
+    requests_kwargs: arguments to be passed to urlopen method
     xarray_kwargs: kwargs to be passed to third-party library (xarray).
     """
     import xarray as xr

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -33,7 +33,7 @@ def to_pandas(
         requests_kwargs = {}
     if pandas_kwargs is None:
         pandas_kwargs = {}
-    data = urlopen(url, **requests_kwargs)
+    data = urlopen(url, requests_kwargs)
     try:
         return pd.read_csv(data, **pandas_kwargs)
     except Exception as e:

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -58,7 +58,7 @@ def to_ncCF(
         )
     if requests_kwargs is None:
         requests_kwargs = {}
-    return _nc_dataset(url, **requests_kwargs)
+    return _nc_dataset(url, requests_kwargs)
 
 
 def to_xarray(
@@ -84,7 +84,7 @@ def to_xarray(
     if response == "opendap":
         return xr.open_dataset(url, **xarray_kwargs)
     else:
-        nc = _nc_dataset(url, **requests_kwargs)
+        nc = _nc_dataset(url, requests_kwargs)
         return xr.open_dataset(xr.backends.NetCDF4DataStore(nc), **xarray_kwargs)
 
 
@@ -106,7 +106,7 @@ def to_iris(
         requests_kwargs = {}
     if iris_kwargs is None:
         iris_kwargs = {}
-    data = urlopen(url, **requests_kwargs)
+    data = urlopen(url, requests_kwargs)
     with _tempnc(data) as tmp:
         cubes = iris.load_raw(tmp, **iris_kwargs)
         _ = [cube.data for cube in cubes]

--- a/erddapy/core/netcdf.py
+++ b/erddapy/core/netcdf.py
@@ -2,7 +2,7 @@
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import BinaryIO, Dict, Generator
+from typing import BinaryIO, Dict, Generator, Optional
 from urllib.parse import urlparse
 
 from erddapy.core.url import urlopen

--- a/erddapy/core/netcdf.py
+++ b/erddapy/core/netcdf.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from erddapy.core.url import urlopen
 
 
-def _nc_dataset(url, **requests_kwargs: Dict):
+def _nc_dataset(url, requests_kwargs: Optional[Dict] = None):
     """Return a netCDF4-python Dataset from memory and fallbacks to disk if that fails."""
     from netCDF4 import Dataset
 

--- a/erddapy/core/netcdf.py
+++ b/erddapy/core/netcdf.py
@@ -12,7 +12,7 @@ def _nc_dataset(url, **requests_kwargs: Dict):
     """Return a netCDF4-python Dataset from memory and fallbacks to disk if that fails."""
     from netCDF4 import Dataset
 
-    data = urlopen(url=url, **requests_kwargs)
+    data = urlopen(url, requests_kwargs)
     try:
         return Dataset(Path(urlparse(url).path).name, memory=data.read())
     except OSError:

--- a/erddapy/core/netcdf.py
+++ b/erddapy/core/netcdf.py
@@ -8,11 +8,11 @@ from urllib.parse import urlparse
 from erddapy.core.url import urlopen
 
 
-def _nc_dataset(url, auth, **requests_kwargs: Dict):
+def _nc_dataset(url, **requests_kwargs: Dict):
     """Return a netCDF4-python Dataset from memory and fallbacks to disk if that fails."""
     from netCDF4 import Dataset
 
-    data = urlopen(url=url, auth=auth, **requests_kwargs)
+    data = urlopen(url=url, **requests_kwargs)
     try:
         return Dataset(Path(urlparse(url).path).name, memory=data.read())
     except OSError:

--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -27,7 +27,6 @@ def _urlopen(url: str, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO
 
 def urlopen(
     url: str,
-    auth: Optional[tuple] = None,
     requests_kwargs: Optional[Dict] = None,
 ) -> BinaryIO:
     """Thin wrapper around httpx get content.
@@ -38,7 +37,7 @@ def urlopen(
     # Ignoring type checks here b/c mypy does not support decorated functions.
     if requests_kwargs is None:
         requests_kwargs = {}
-    data = _urlopen(url=url, auth=auth, **requests_kwargs)  # type: ignore
+    data = _urlopen(url, **requests_kwargs)  # type: ignore
     data.seek(0)
     return data
 

--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -25,14 +25,20 @@ def _urlopen(url: str, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO
     return io.BytesIO(response.content)
 
 
-def urlopen(url: str, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO:
+def urlopen(
+    url: str,
+    auth: Optional[tuple] = None,
+    requests_kwargs: Optional[Dict] = None,
+) -> BinaryIO:
     """Thin wrapper around httpx get content.
 
     See httpx.get docs for the `params` and `kwargs` options.
 
     """
     # Ignoring type checks here b/c mypy does not support decorated functions.
-    data = _urlopen(url=url, auth=auth, **kwargs)  # type: ignore
+    if requests_kwargs is None:
+        requests_kwargs = {}
+    data = _urlopen(url=url, auth=auth, **requests_kwargs)  # type: ignore
     data.seek(0)
     return data
 

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -393,7 +393,7 @@ class ERDDAP:
         url = self.get_info_url(dataset_id=dataset_id, response="csv")
 
         variables = {}
-        data = urlopen(url, auth=self.auth, **self.requests_kwargs)
+        data = urlopen(url, self.requests_kwargs)
         _df = pd.read_csv(data)
         self._dataset_id = dataset_id
         for variable in set(_df["Variable Name"]):

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -331,10 +331,14 @@ class ERDDAP:
             **kwargs,
         )
 
-    def to_pandas(self, **kw):
+    def to_pandas(
+        self,
+        requests_kwargs: Optional[Dict] = None,
+        pandas_kwargs: Optional[Dict] = None,
+    ):
         """Save a data request to a pandas.DataFrame.
 
-        Accepts any `pandas.read_csv` keyword arguments.
+        Accepts any `pandas.read_csv` keyword arguments, passed as a dictionary to pandas_kwargs.
 
         This method uses the .csvp [1] response as the default for simplicity,
         please check ERDDAP's documentation for the other csv options available.
@@ -342,9 +346,11 @@ class ERDDAP:
         [1] Download a ISO-8859-1 .csv file with line 1: name (units). Times are ISO 8601 strings.
 
         """
-        response = kw.pop("response", "csvp")
-        url = self.get_download_url(response=response, **kw)
-        return to_pandas(url, **kw)
+        if requests_kwargs is None:
+            requests_kwargs = {}
+        response = requests_kwargs.pop("response", "csvp")
+        url = self.get_download_url(response=response, **requests_kwargs)
+        return to_pandas(url, requests_kwargs, pandas_kwargs)
 
     def to_ncCF(self, protocol: str = None, **kw):
         """Load the data request into a Climate and Forecast compliant netCDF4-python object."""

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -364,7 +364,8 @@ class ERDDAP:
         else:
             response = "ncCF"
         url = self.get_download_url(response=response)
-        return to_xarray(url, response=response, auth=self.auth, **kw)
+        requests_kwargs = dict(auth=self.auth)
+        return to_xarray(url, response, requests_kwargs, **kw)
 
     def to_iris(self, **kw):
         """Load the data request into an iris.CubeList.

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -350,7 +350,7 @@ class ERDDAP:
         """Load the data request into a Climate and Forecast compliant netCDF4-python object."""
         protocol = protocol if protocol else self.protocol
         url = self.get_download_url(response="ncCF", **kw)
-        return to_ncCF(url, protocol=protocol, **kw)
+        return to_ncCF(url, protocol=protocol, requests_kwargs=dict(**kw))
 
     def to_xarray(self, **kw):
         """Load the data request into a xarray.Dataset.
@@ -365,7 +365,7 @@ class ERDDAP:
             response = "ncCF"
         url = self.get_download_url(response=response)
         requests_kwargs = dict(auth=self.auth)
-        return to_xarray(url, response, requests_kwargs, **kw)
+        return to_xarray(url, response, requests_kwargs, xarray_kwargs=dict(**kw))
 
     def to_iris(self, **kw):
         """Load the data request into an iris.CubeList.
@@ -374,7 +374,7 @@ class ERDDAP:
         """
         response = "nc" if self.protocol == "griddap" else "ncCF"
         url = self.get_download_url(response=response, **kw)
-        return to_iris(url, **kw)
+        return to_iris(url, iris_kwargs=dict(**kw))
 
     @functools.lru_cache(maxsize=None)
     def _get_variables(self, dataset_id: OptionalStr = None) -> Dict:

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -331,11 +331,7 @@ class ERDDAP:
             **kwargs,
         )
 
-    def to_pandas(
-        self,
-        requests_kwargs: Optional[Dict] = None,
-        pandas_kwargs: Optional[Dict] = None,
-    ):
+    def to_pandas(self, **kw):
         """Save a data request to a pandas.DataFrame.
 
         Accepts any `pandas.read_csv` keyword arguments, passed as a dictionary to pandas_kwargs.
@@ -346,11 +342,9 @@ class ERDDAP:
         [1] Download a ISO-8859-1 .csv file with line 1: name (units). Times are ISO 8601 strings.
 
         """
-        if requests_kwargs is None:
-            requests_kwargs = {}
-        response = requests_kwargs.pop("response", "csvp")
-        url = self.get_download_url(response=response, **requests_kwargs)
-        return to_pandas(url, requests_kwargs, pandas_kwargs)
+        response = kw.pop("response", "csvp")
+        url = self.get_download_url(response=response, **kw)
+        return to_pandas(url, pandas_kwargs=dict(**kw))
 
     def to_ncCF(self, protocol: str = None, **kw):
         """Load the data request into a Climate and Forecast compliant netCDF4-python object."""

--- a/notebooks/00-quick_intro.ipynb
+++ b/notebooks/00-quick_intro.ipynb
@@ -67,7 +67,7 @@
     "]\n",
     "\n",
     "e.constraints = {\n",
-    "    \"time>=\": \"now-7days\",\n",
+    "    \"time>=\": \"2000-01-01\",\n",
     "}\n",
     "\n",
     "\n",
@@ -196,7 +196,7 @@
   },
   "gist_id": "3f0f25b13ade0c64c84607bd92903d1b",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.4 ('erddapy')",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/00-quick_intro.ipynb
+++ b/notebooks/00-quick_intro.ipynb
@@ -179,6 +179,7 @@
     "    parse_dates=True,\n",
     ").dropna()\n",
     "\n",
+    "\n",
     "df.head()"
    ]
   }

--- a/notebooks/01a-griddap.ipynb
+++ b/notebooks/01a-griddap.ipynb
@@ -129,8 +129,8 @@
    "source": [
     "def bounds2contraints(bounds):\n",
     "    return {\n",
-    "        \"longitude>=\": bounds.minx.squeeze(),\n",
-    "        \"longitude<=\": bounds.maxx.squeeze(),\n",
+    "        \"longitude>=\": 360 - abs(bounds.minx.squeeze()),  # convert longitude to 360 format\n",
+    "        \"longitude<=\": 360 - abs(bounds.maxx.squeeze()),\n",
     "        \"latitude>=\": bounds.miny.squeeze(),\n",
     "        \"latitude<=\": bounds.maxy.squeeze(),\n",
     "    }\n",

--- a/tests/test_netcdf_handling.py
+++ b/tests/test_netcdf_handling.py
@@ -16,8 +16,7 @@ def test__nc_dataset_in_memory_https():
     from netCDF4 import Dataset
 
     url = "http://erddap.ioos.us/erddap/tabledap/allDatasets.nc"  # noqa
-    auth = None
-    _nc = _nc_dataset(url, auth)
+    _nc = _nc_dataset(url)
     assert isinstance(_nc, Dataset)
     assert _nc.filepath() == url.split("/")[-1]
 

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -105,7 +105,8 @@ def test_to_pandas(dataset_tabledap):
     import pandas as pd
 
     df = dataset_tabledap.to_pandas(
-        pandas_kwargs={"index_col": "time (UTC)", "parse_dates": True},
+        index_col="time (UTC)",
+        parse_dates=True,
     ).dropna()
 
     assert isinstance(df, pd.DataFrame)

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -104,7 +104,9 @@ def test_to_pandas(dataset_tabledap):
     """Test converting tabledap to a pandas DataFrame."""
     import pandas as pd
 
-    df = dataset_tabledap.to_pandas(index_col="time (UTC)", parse_dates=True).dropna()
+    df = dataset_tabledap.to_pandas(
+        pandas_kwargs={"index_col": "time (UTC)", "parse_dates": True},
+    ).dropna()
 
     assert isinstance(df, pd.DataFrame)
     assert df.index.name == "time (UTC)"


### PR DESCRIPTION
Hi,

This is something I caught while running the `ds = e.to_xarray(decode_times=False)` line in `02-extras.ipynb`.

**Summary of changes**
  - Fix kwargs propagation for urlopen and third-party libraries
  - Improve docstrings
  - Add typing.Dict for type annotation