### PR TITLE
Add public methods to erddapy module

### DIFF
--- a/erddapy/__init__.py
+++ b/erddapy/__init__.py
@@ -1,9 +1,31 @@
 """Easier access to scientific data."""
 
+from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
+from erddapy.core.url import (
+    get_categorize_url,
+    get_download_url,
+    get_info_url,
+    get_search_url,
+    parse_dates,
+    urlopen,
+)
 from erddapy.erddapy import ERDDAP
 from erddapy.servers.servers import servers
 
-__all__ = ["ERDDAP", "servers"]
+__all__ = [
+    "ERDDAP",
+    "servers",
+    "get_categorize_url",
+    "get_download_url",
+    "get_info_url",
+    "get_search_url",
+    "parse_dates",
+    "urlopen",
+    "to_ncCF",
+    "to_iris",
+    "to_pandas",
+    "to_xarray",
+]
 
 try:
     from ._version import __version__

--- a/erddapy/__init__.py
+++ b/erddapy/__init__.py
@@ -1,30 +1,11 @@
 """Easier access to scientific data."""
 
-from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
-from erddapy.core.url import (
-    get_categorize_url,
-    get_download_url,
-    get_info_url,
-    get_search_url,
-    parse_dates,
-    urlopen,
-)
 from erddapy.erddapy import ERDDAP
 from erddapy.servers.servers import servers
 
 __all__ = [
     "ERDDAP",
     "servers",
-    "get_categorize_url",
-    "get_download_url",
-    "get_info_url",
-    "get_search_url",
-    "parse_dates",
-    "urlopen",
-    "to_ncCF",
-    "to_iris",
-    "to_pandas",
-    "to_xarray",
 ]
 
 try:

--- a/erddapy/core/__init__.py
+++ b/erddapy/core/__init__.py
@@ -3,3 +3,24 @@ Core subpackage for the erddapy parent package.
 
 This package contains the URL and data handling functionalities.
 """
+
+from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
+from erddapy.core.url import (
+    get_categorize_url,
+    get_download_url,
+    get_info_url,
+    get_search_url,
+    parse_dates,
+)
+
+__all__ = [
+    "get_categorize_url",
+    "get_download_url",
+    "get_info_url",
+    "get_search_url",
+    "parse_dates",
+    "to_iris",
+    "to_ncCF",
+    "to_pandas",
+    "to_xarray",
+]


### PR DESCRIPTION
Hi,

while working on the docs for the core interface, I realised that the URL parsing and interfaces methods would have to be directly imported from their respective modules, rather than being accessed from the `erddapy` module. This seemed a bit unintuitive, so I added public methods directly to the `erddapy.__init__` module.

Users can then run:
```python
from erddapy import get_download_url, to_pandas

url = get_download_url(...)
df = to_pandas(url)

# or
import erddapy

url = erddapy.get_download_url(...)
df = erddapy.to_pandas(url)
```

instead of

```python
from erddapy.core.url import get_download_url
from erddapy.core.interfaces import to_pandas
```

which seems much harder to do.

**Summary of changes:**
  - Add public methods to `erddapy.__init__`

  This allows using the URL parsing and interfaces methods directly from the erddapy module,
  without having to access the core.url and core.interfaces modules.