### PR TITLE
Add notebook documenting usage of core layer

### DIFF
--- a/erddapy/__init__.py
+++ b/erddapy/__init__.py
@@ -1,9 +1,31 @@
 """Easier access to scientific data."""
 
+from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
+from erddapy.core.url import (
+    get_categorize_url,
+    get_download_url,
+    get_info_url,
+    get_search_url,
+    parse_dates,
+    urlopen,
+)
 from erddapy.erddapy import ERDDAP
 from erddapy.servers.servers import servers
 
-__all__ = ["ERDDAP", "servers"]
+__all__ = [
+    "ERDDAP",
+    "servers",
+    "get_categorize_url",
+    "get_download_url",
+    "get_info_url",
+    "get_search_url",
+    "parse_dates",
+    "urlopen",
+    "to_ncCF",
+    "to_iris",
+    "to_pandas",
+    "to_xarray",
+]
 
 try:
     from ._version import __version__

--- a/erddapy/__init__.py
+++ b/erddapy/__init__.py
@@ -1,30 +1,11 @@
 """Easier access to scientific data."""
 
-from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
-from erddapy.core.url import (
-    get_categorize_url,
-    get_download_url,
-    get_info_url,
-    get_search_url,
-    parse_dates,
-    urlopen,
-)
 from erddapy.erddapy import ERDDAP
 from erddapy.servers.servers import servers
 
 __all__ = [
     "ERDDAP",
     "servers",
-    "get_categorize_url",
-    "get_download_url",
-    "get_info_url",
-    "get_search_url",
-    "parse_dates",
-    "urlopen",
-    "to_ncCF",
-    "to_iris",
-    "to_pandas",
-    "to_xarray",
 ]
 
 try:

--- a/erddapy/core/__init__.py
+++ b/erddapy/core/__init__.py
@@ -3,3 +3,24 @@ Core subpackage for the erddapy parent package.
 
 This package contains the URL and data handling functionalities.
 """
+
+from erddapy.core.interfaces import to_iris, to_ncCF, to_pandas, to_xarray
+from erddapy.core.url import (
+    get_categorize_url,
+    get_download_url,
+    get_info_url,
+    get_search_url,
+    parse_dates,
+)
+
+__all__ = [
+    "get_categorize_url",
+    "get_download_url",
+    "get_info_url",
+    "get_search_url",
+    "parse_dates",
+    "to_iris",
+    "to_ncCF",
+    "to_pandas",
+    "to_xarray",
+]

--- a/notebooks/04-refactor-update.ipynb
+++ b/notebooks/04-refactor-update.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "erddapy has recently been refactored into core and opinionated layers. What this means is that it's now possible to reuse basic erddapy functionality without having to rely on the main `ERDDAP` class. \n",
     "\n",
-    "Public methods are now directly accessible from the `erddapy` module. This includes URL parsing (`get_categorize_url`, `get_download_url`, etc.) and methods that convert an URL to a Python data object (`to_iris`, `to_pandas`, etc.).\n",
+    "Public methods are now directly accessible from the `erddapy.core` module. This includes URL parsing (`get_categorize_url`, `get_download_url`, etc.) and methods that convert an URL to a Python data object (`to_iris`, `to_pandas`, etc.).\n",
     "\n",
     "This is how it looks like:"
    ]

--- a/notebooks/04-refactor-update.ipynb
+++ b/notebooks/04-refactor-update.ipynb
@@ -101,21 +101,13 @@
     "df = erddapy.core.to_pandas(url)\n",
     "df.head()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a5f89795-d3d0-40da-9586-e33e205b5242",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:erddapy]",
+   "display_name": "Python 3.10.4 ('erddapy')",
    "language": "python",
-   "name": "conda-env-erddapy-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -128,6 +120,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "25f34034045c971a17cd2c513c30c777dac49b833caf3401bca1a766b0494fa4"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/04-refactor-update.ipynb
+++ b/notebooks/04-refactor-update.ipynb
@@ -21,9 +21,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Methods available in the erddapy module\n",
+    "# Methods available in the erddapy 'core' module\n",
     "import erddapy\n",
-    "[i for i in dir(erddapy) if not i.startswith(\"_\")]"
+    "[i for i in dir(erddapy.core) if not i.startswith(\"_\")]"
    ]
   },
   {
@@ -78,7 +78,7 @@
     "}\n",
     "\n",
     "# Using an URL method\n",
-    "url = erddapy.get_download_url(\n",
+    "url = erddapy.core.get_download_url(\n",
     "    server=server,\n",
     "    dataset_id=\"scrippsGliders\",\n",
     "    protocol=\"tabledap\",\n",
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "# Converting url to a Pandas dataframe with the `to_pandas` interface method\n",
-    "df = erddapy.to_pandas(url)\n",
+    "df = erddapy.core.to_pandas(url)\n",
     "df.head()"
    ]
   },

--- a/notebooks/04-refactor-update.ipynb
+++ b/notebooks/04-refactor-update.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0946e5b8-1602-4455-9357-7489225fdd15",
+   "metadata": {},
+   "source": [
+    "# 2022 Refactor update\n",
+    "\n",
+    "erddapy has recently been refactored into core and opinionated layers. What this means is that it's now possible to reuse basic erddapy functionality without having to rely on the main `ERDDAP` class. \n",
+    "\n",
+    "Public methods are now directly accessible from the `erddapy` module. This includes URL parsing (`get_categorize_url`, `get_download_url`, etc.) and methods that convert an URL to a Python data object (`to_iris`, `to_pandas`, etc.).\n",
+    "\n",
+    "This is how it looks like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f003f4a-2a57-4b72-b53a-bce1f56b4ba5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Methods available in the erddapy module\n",
+    "import erddapy\n",
+    "[i for i in dir(erddapy) if not i.startswith(\"_\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dbab799-da6f-4b46-a400-0c264cdaf3b8",
+   "metadata": {},
+   "source": [
+    "URL methods are `get_categorize_url`, `get_download_url`, `get_info_url`, `get_search_url`, `urlopen`, `parse_dates`, and live in the `erddapy.core.url` module. These modules form URLs from server and dataset information.\n",
+    "\n",
+    "Interface methods are `to_iris`, `to_ncCF`, `to_pandas`, `to_xarray`, and live in the `erddapy.core.interfaces` module. These request an URL and process the response into datasets objects for each library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1d04379-fd82-4f58-97eb-1456a4b1998e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The 'server' object contains a dictionary of ERDDAP servers\n",
+    "erddapy.servers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a19eef3-fecc-4261-bf60-c63b41218b05",
+   "metadata": {},
+   "source": [
+    "### Let's perform the same request from the \"Quick Start\" notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7932ca36-3bc2-49b4-80fa-d848b1f4aa05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access a server by its `url` attribute\n",
+    "server = erddapy.servers[\"uaf\"].url\n",
+    "\n",
+    "variables = [\n",
+    "    \"depth\",\n",
+    "    \"latitude\",\n",
+    "    \"longitude\",\n",
+    "    \"salinity\",\n",
+    "    \"temperature\",\n",
+    "    \"time\",\n",
+    "]\n",
+    "constraints = {\n",
+    "    \"time>=\": \"now-7days\",\n",
+    "}\n",
+    "\n",
+    "# Using an URL method\n",
+    "url = erddapy.get_download_url(\n",
+    "    server=server,\n",
+    "    dataset_id=\"scrippsGliders\",\n",
+    "    protocol=\"tabledap\",\n",
+    "    response=\"csv\",\n",
+    "    variables=variables,\n",
+    "    constraints=constraints\n",
+    ")\n",
+    "\n",
+    "print(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b4e96d8-1b0c-4803-95ba-8dd2c49ccbc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Converting url to a Pandas dataframe with the `to_pandas` interface method\n",
+    "df = erddapy.to_pandas(url)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5f89795-d3d0-40da-9586-e33e205b5242",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:erddapy]",
+   "language": "python",
+   "name": "conda-env-erddapy-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hi,

This PR adds `notebooks/04-refactor-update.ipynb` documenting how to use public methods from the core layer.

I intend to improve this in the future, but I just added a basic example for now.

This PR contains 3ed7d61057fa7231ac8c96b39de6f9bcae3dd667 from #281.

Thanks