### PR TITLE
pandas 2.0 support

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -9,9 +9,7 @@ from urllib.parse import quote_plus
 
 import httpx
 import pytz
-from pandas._libs.tslibs.parsing import (
-    py_parse_datetime_string as _py_parse_datetime_string,
-)
+from pandas import to_datetime
 
 ListLike = Union[List[str], Tuple[str]]
 OptionalStr = Optional[str]
@@ -129,11 +127,11 @@ def parse_dates(
 
     """
     if isinstance(date_time, str):
-        parse_date_time = _py_parse_datetime_string(
+        parse_date_time = to_datetime(
             date_time,
             dayfirst=dayfirst,
             yearfirst=yearfirst,
-        )
+        ).to_pydatetime()
     else:
         parse_date_time = date_time
 

--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -9,7 +9,9 @@ from urllib.parse import quote_plus
 
 import httpx
 import pytz
-from pandas._libs.tslibs.parsing import parse_time_string
+from pandas._libs.tslibs.parsing import (
+    py_parse_datetime_string as _py_parse_datetime_string,
+)
 
 ListLike = Union[List[str], Tuple[str]]
 OptionalStr = Optional[str]
@@ -113,7 +115,11 @@ def _check_substrings(constraint):
     return any([True for substring in substrings if substring in str(constraint)])
 
 
-def parse_dates(date_time: Union[datetime, str]) -> float:
+def parse_dates(
+    date_time: Union[datetime, str],
+    dayfirst=False,
+    yearfirst=False,
+) -> float:
     """
     Parse dates to ERDDAP internal format.
 
@@ -123,9 +129,11 @@ def parse_dates(date_time: Union[datetime, str]) -> float:
 
     """
     if isinstance(date_time, str):
-        # pandas returns a tuple with datetime, dateutil, and string representation.
-        # we want only the datetime obj.
-        parse_date_time = parse_time_string(date_time)[0]
+        parse_date_time = _py_parse_datetime_string(
+            date_time,
+            dayfirst=dayfirst,
+            yearfirst=yearfirst,
+        )
     else:
         parse_date_time = date_time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ markers = [
     "serial: marks tests that cannot be run in parallel (deselect with '-m \"not serial\"')",
 ]
 filterwarnings = [
-    "error",
+    "error:::erddapy.*",
     "ignore::UserWarning",
     "ignore::RuntimeWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools_scm]
 write_to = "erddapy/_version.py"
 write_to_template = "__version__ = '{version}'"
+tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.pytest.ini_options]
 markers = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ geopandas
 interrogate
 joblib
 jupyter
+nbconvert<7.3.0
 nbsphinx
 netcdf4
 pendulum>=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 httpx
-pandas>=0.20.3
+pandas>=2
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 httpx
-pandas>=1.5.3
+pandas>=0.25.2,<3
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 httpx
-pandas>=2
+pandas>=1.5.3
 pytz


### PR DESCRIPTION
Closes #299 

In this PR:
- We are still relying on a private function but that code is the best there is :-/
- We are pinning to pandas >=2.0. Should be OK b/c we are patching the previous released erddapies to work with older pandas only (conda-forge), there is nothing we can do for PyPI;
- Re-added the tag regex that was accidentally removed;
- Added the `dayfirst` and `yearfirst` options to `parse_dates`. Only the default work when calling it internally but a user has the option to convert the date themselves this way.
