### PR TITLE
increase default httpx timeout to 60 seconds

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -17,6 +17,8 @@ OptionalStr = Optional[str]
 
 @functools.lru_cache(maxsize=128)
 def _urlopen(url: str, auth: Optional[tuple] = None, **kwargs: Dict) -> BinaryIO:
+    if "timeout" not in kwargs.keys():
+        kwargs["timeout"] = 60
     response = httpx.get(url, follow_redirects=True, auth=auth, **kwargs)
     try:
         response.raise_for_status()


### PR DESCRIPTION
Following the recommendation in #314. Default setting is 5 seconds. 60 is just a suggestion based on the test introduced in #304 