### PR TITLE
fix httpx status check change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-httpx
+httpx>=0.25.0
 pandas>=0.25.2,<3
 pytz

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -91,7 +91,7 @@ def test_erddap2_10():
     e = ERDDAP(server="http://erddap.ioos.us/erddap/")
     url = e.get_search_url(search_for="NOAA", response="csv")
     r = httpx.head(url)
-    assert r.raise_for_status() is None
+    assert r.status_code == 200
 
 
 def test__griddap_check_constraints():


### PR DESCRIPTION
Latest `httpx` change the OK report from `None` to 200 OK status. While the current version of the tests will work with past version of `httpx` I'm pinning to modern versions for maintainability.