### PR TITLE
Fix datetime deprecation in Python >=3.11

### DIFF
--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -4,7 +4,6 @@ Interface between URL responses and third-party libraries.
 This module takes an URL or the bytes response of a request and converts it to Pandas,
 XArray, Iris, etc. objects.
 """
-
 from typing import TYPE_CHECKING
 
 import pandas as pd

--- a/erddapy/core/interfaces.py
+++ b/erddapy/core/interfaces.py
@@ -4,6 +4,7 @@ Interface between URL responses and third-party libraries.
 This module takes an URL or the bytes response of a request and converts it to Pandas,
 XArray, Iris, etc. objects.
 """
+
 from typing import TYPE_CHECKING
 
 import pandas as pd

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -1,6 +1,6 @@
 """Test ERDDAP functionality."""
 
-from datetime import datetime
+import datetime
 
 import httpx
 import pytest
@@ -20,19 +20,19 @@ from erddapy.erddapy import ERDDAP
 
 def test_parse_dates_naive_datetime():
     """Naive timestamp at 1970-1-1 must be 0."""
-    d = datetime(1970, 1, 1, 0, 0)
+    d = datetime.datetime(1970, 1, 1, 0, 0)
     assert parse_dates(d) == 0
 
 
 def test_parse_dates_utc_datetime():
     """UTC timestamp at 1970-1-1 must be 0."""
-    d = datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)
+    d = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)
     assert parse_dates(d) == 0
 
 
 def test_parse_dates_nonutc_datetime():
     """Non-UTC timestamp at 1970-1-1 must have the zone offset."""
-    d = datetime(1970, 1, 1, tzinfo=pytz.timezone("US/Eastern"))
+    d = datetime.datetime(1970, 1, 1, tzinfo=pytz.timezone("US/Eastern"))
     assert parse_dates(d) == abs(d.utcoffset().total_seconds())
 
 
@@ -52,7 +52,7 @@ def test__quote_string_constraints():
         {
             "latitude": 42,
             "longitude": 42.0,
-            "max_time": datetime.utcnow(),
+            "max_time": datetime.datetime.now(datetime.UTC),
             "min_time": "1970-01-01T00:00:00Z",
             "cdm_data_type": "trajectoryprofile",
         },
@@ -60,7 +60,7 @@ def test__quote_string_constraints():
 
     assert isinstance(kw["latitude"], int)
     assert isinstance(kw["longitude"], float)
-    assert isinstance(kw["max_time"], datetime)
+    assert isinstance(kw["max_time"], datetime.datetime)
     assert isinstance(kw["min_time"], str)
     assert isinstance(kw["cdm_data_type"], str)
 

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -1,8 +1,10 @@
 """Test ERDDAP functionality."""
 
 import datetime
+import sys
 
 import httpx
+import packaging.version
 import pytest
 import pytz
 
@@ -16,6 +18,13 @@ from erddapy.core.url import (
     parse_dates,
 )
 from erddapy.erddapy import ERDDAP
+
+if packaging.version.parse(
+    f"{sys.version_info.major}.{sys.version_info.minor}",
+) < packaging.version.parse(
+    "3.11",
+):
+    datetime.UTC = datetime.timezone.utc
 
 
 def test_parse_dates_naive_datetime():


### PR DESCRIPTION
`datetime.utcnow()` is deprecated in lieu from `datetime.datetime.now(datetime.UTC)`.