### PR TITLE
Automatically call griddap_initialize if a dataset_id exists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,14 +50,14 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.2
+  rev: v0.8.0
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
     - id: ruff-format
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.8.7
+  rev: 1.9.1
   hooks:
     - id: nbqa-check-ast
     - id: nbqa-black

--- a/erddapy/core/griddap.py
+++ b/erddapy/core/griddap.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import functools
-
 import pandas as pd
 
 from erddapy.core.url import urlopen
@@ -11,7 +9,6 @@ from erddapy.core.url import urlopen
 OptionalList = list[str] | tuple[str] | None
 
 
-@functools.lru_cache(maxsize=128)
 def _griddap_get_constraints(
     dataset_url: str,
     step: int,

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -34,13 +34,13 @@ from erddapy.servers.servers import servers
 
 # Objects used by downstream packages
 __all__ = [
+    "ERDDAP",
     "_check_substrings",
     "_distinct",
     "_format_constraints_url",
     "_quote_string_constraints",
     "parse_dates",
     "urlopen",
-    "ERDDAP",
 ]
 
 if TYPE_CHECKING:

--- a/notebooks/01a-griddap.ipynb
+++ b/notebooks/01a-griddap.ipynb
@@ -71,8 +71,7 @@
     "CAVEAT: Note that ERDDAP can serve gridded data with longitudes in the 0&ndash;360 format or -180&ndash;180.\n",
     "The user must inspect the dataset and modify your query accordingly.\n",
     "\n",
-    "Information on the griddap dataset is fetched with `griddap_initialize`.\n",
-    "This fills in the `variables` and `constraints` properties for that dataset."
+    "Information on the griddap dataset is fetched automatically and the `variables` and `constraints` properties for that dataset are filled using ERDDAP's defaults."
    ]
   },
   {
@@ -83,9 +82,32 @@
    "source": [
     "import json\n",
     "\n",
-    "e.griddap_initialize()\n",
+    "constraints = json.dumps(e.constraints, indent=1)\n",
     "\n",
     "print(f\"variables in this dataset:\\n\\n{e.variables}\")\n",
+    "print(f\"\\nconstraints of this dataset:\\n\\n{constraints}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ERDDAP's standard subsetting return all variables at the most recent timestep and every point of the remaining dimensions.\n",
+    "\n",
+    "This can result in large data requests!\n",
+    "However, the values of the constraints can be changed and variables dropped before data set is downloaded.\n",
+    "Here we will download only one variable from that list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e.constraints[\"latitude_step\"] = 10\n",
+    "e.constraints[\"longitude_step\"] = 10\n",
+    "\n",
     "constraints = json.dumps(e.constraints, indent=1)\n",
     "print(f\"\\nconstraints of this dataset:\\n\\n{constraints}\")"
    ]
@@ -94,11 +116,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default behaviour is to use erddap standard subsetting to return all variables at the most recent timestep and every point of the remaining dimensions.\n",
+    "The user can reset to the defaults with `griddap_initialize()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e.griddap_initialize()\n",
     "\n",
-    "This can result in large data requests!\n",
-    "However, the values of the constraints can be changed and variables dropped before data set is downloaded.\n",
-    "Here we will download only one variable from that list."
+    "constraints = json.dumps(e.constraints, indent=1)\n",
+    "print(f\"\\nconstraints of this dataset:\\n\\n{constraints}\")"
    ]
   },
   {
@@ -259,13 +289,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The data can be downloaded immediately, no need to run `griddap_initialize`\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -332,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Right now we need this extra step for `griddap` but we can skip it run that automatically every time a `dataset_id` is set.