### PR TITLE
Always quote params in queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.3
+  rev: v0.6.5
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
@@ -73,7 +73,7 @@ repos:
     - id: nb-strip-paths
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 2.2.1
+  rev: 2.2.4
   hooks:
     - id: pyproject-fmt
 


### PR DESCRIPTION
I'm planning on a bugfix relase ASAP b/c the `urlopen` functionality is broken in ERDDAP 2.23 without this PR.