### PR TITLE
oddily ncCF datasets cannot be quoted

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -25,8 +25,12 @@ OptionalList = list[str] | tuple[str] | None
 
 def quote_url(url: str) -> str:
     """Quote URL args for modern ERDDAP servers."""
-    # We should always quote for queries.
-    if "?" in url and "/erddap/search/" not in url:
+    # No idea why csv must be quoted in 2.23 but ncCF doesn't :-/
+    do_not_quote = ["/erddap/search/", "ncCF"]
+    if any(True for string in do_not_quote if string in url):
+        return url
+    # We should always quote some queries.
+    if "?" in url:
         base, unquoted = url.split("?")
         url = f"{base}?{parse.quote_plus(unquoted)}"
     return url

--- a/tests/test_to_objects.py
+++ b/tests/test_to_objects.py
@@ -147,6 +147,19 @@ def test_to_xarray_tabledap(dataset_tabledap):
 
 
 @pytest.mark.web
+def test_to_xarray_cannot_be_quoted():
+    """Test dataset that failed when quoted."""
+    e = ERDDAP(server="https://erddap.aoos.org/erddap/", protocol="tabledap")
+    e.dataset_id = "kotzebue-alaska-water-level"
+    e.constraints = {
+        "time>=": "2018-09-05T21:00:00Z",
+        "time<=": "2019-07-10T19:00:00Z",
+    }
+    ds = e.to_xarray()
+    assert isinstance(ds, xr.Dataset)
+
+
+@pytest.mark.web
 def test_to_xarray_requests_kwargs(dataset_tabledap):
     """Test converting tabledap to an xarray Dataset with manual timeout."""
     ds = dataset_tabledap.to_xarray(requests_kwargs={"timeout": 30})


### PR DESCRIPTION
I'm starting to wonder if we do need to quote all URLs. The behavior doesn't seem to be consistent as Bob told me. Maybe we should revert all this and quote only the rare cases where `"` is present. Anyway, let's give this one last go.