### PR TITLE
Fix CO-OPS URL

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -84,6 +84,18 @@ def urlopen(
     See httpx.get docs for the `params` and `kwargs` options.
 
     """
+    # This is a horrible hack to work around opendap.co-ops.nos.noaa.gov.
+    # The co-ops serve require variable in a specific order to work.
+    date_string = ("BEGIN_DATE", "END_DATE")
+    if "opendap.co-ops.nos.noaa.gov" in url:
+        dates, base = [], []
+        for part in url.split("&"):
+            if part.startswith(date_string):
+                dates.append(part)
+            else:
+                base.append(part)
+        url = "&".join(base + dates)
+
     if requests_kwargs is None:
         requests_kwargs = {}
     data = _urlopen(url, **requests_kwargs)

--- a/tests/test_url_handling.py
+++ b/tests/test_url_handling.py
@@ -70,6 +70,15 @@ def test__sort_url_undefined_query():
 
 def test_quoting():
     """Test quoting query params for ERDDAP 2.23."""
-    url = 'https://opendap.co-ops.nos.noaa.gov/erddap/tabledap/IOOS_Hourly_Height_Verified_Water_Level.csvp?WL_VALUE,time&BEGIN_DATE="2016-10-04"&END_DATE="2016-10-12"&DATUM="MSL"&STATION_ID="8729840"'
+    url = (
+        "https://opendap.co-ops.nos.noaa.gov/erddap/tabledap/"
+        "IOOS_Hourly_Height_Verified_Water_Level.csvp?"
+        "WL_VALUE,"
+        "time&"
+        'DATUM="MSL"&'
+        'BEGIN_DATE="20161004"&'
+        'END_DATE="20161004"&'
+        'STATION_ID="8729840"'
+    )
     data = urlopen(url)
     assert data is not None


### PR DESCRIPTION
The date format change, the double quotes are still required, and there is now an odd variable order to the URL in order to make it a valid request.