### PR TITLE
run all on Linux and latest on the rest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,12 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
-        os: [ windows-latest, ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
+        include:
+          - os: windows-latest
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.13"
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
Let's try to reduce the load on the servers. We don't need to run everything in all OSes.