### PR TITLE
Do not cache check_url_response()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       files: requirements-dev.txt
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.20.1
+  rev: v1.20.2
   hooks:
   - id: mypy
     exclude: docs/source/conf.py

--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -116,7 +116,6 @@ def urlopen(
     return data
 
 
-@functools.lru_cache(maxsize=128)
 def check_url_response(url: str, **kwargs: dict) -> str:
     """Shortcut to `raise_for_status` instead of fetching the whole content.
 

--- a/tests/cassettes/test_url_builder/test_download_url_distinct.yaml
+++ b/tests/cassettes/test_url_builder/test_download_url_distinct.yaml
@@ -13,6 +13,78 @@ interactions:
       User-Agent:
       - python-httpx/0.28.1
     method: HEAD
+    uri: https://standards.sensors.ioos.us/erddap/tabledap/org_cormp_cap2.htmlTable?station,z
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self''; script-src ''self'' ''unsafe-inline'' ''unsafe-eval''
+        data: blob: http://*.axds.co http://*.axiomalaska.com http://*.axiomdatascience.com
+        http://*.aoos.org http://*.ioos.us http://cdnjs.cloudflare.com http://d3js.org
+        http://maps.googleapis.com http://www.youtube.com http://www.googletagmanager.com
+        http://cdn.jsdelivr.net http://dgd6r9iiqa8y9.cloudfront.net; style-src ''self''
+        ''unsafe-inline'' http://*.axds.co http://*.axiomalaska.com http://fonts.googleapis.com
+        http://cdn.jsdelivr.net http://dgd6r9iiqa8y9.cloudfront.net; object-src ''none'';
+        base-uri ''self'' http://www.opendap.org; connect-src ''self'' http://*.axds.co
+        http://*.axiomalaska.com http://*.axiomdatascience.com http://*.ioos.us http://maps.googleapis.com
+        http://www.google-analytics.com http://cdn.jsdelivr.net; font-src ''self''
+        data: http://fonts.gstatic.com http://cdn.jsdelivr.net; frame-src ''self''
+        http://*.axiomalaska.com http://www.youtube.com; img-src ''self'' data: http://*.axds.co
+        http://*.axiomalaska.com http://*.mapbox.com http://*.openstreetmap.org http://maps.googleapis.com
+        http://*.noaa.gov http://maps.gstatic.com http://www2.demis.nl http://ahocevar.com
+        http://*.nasa.gov http://godiva.reading.ac.uk http://www.gebco.net http://wms.gebco.net
+        http://*.api.mapbox.com http://*.alaska.gov http://fishingstatus.com http://images.marinespecies.org
+        http://images.squarespace-cdn.com http://ioos.us http://server.arcgisonline.com
+        http://upload.wikimedia.org http://wms.chartbundle.com http://www.gmrt.org
+        http://secoora.org http://www.gravatar.com http://www.googletagmanager.com
+        http://*.amazonaws.com http://cdn.jsdelivr.net http://dgd6r9iiqa8y9.cloudfront.net;
+        manifest-src ''self''; media-src ''self'' http://*.amazonaws.com http://cdn.jsdelivr.net;
+        worker-src blob:; form-action http://status.atn.ioos.us http://atn.ioos.us
+        http://portal.atn.ioos.us http://mbon.ioos.us http://sensors.ioos.us http://standards.sensors.ioos.us
+        http://beta.sensors.ioos.us http://video.ioos.us http://dacregistration.atn.ioos.us;
+        report-uri https://sentry.srv.axds.co/api/2/security/?sentry_key=7de616494a2346fb8fdf8cd018062730&sentry_version=7'
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Fri, 24 Apr 2026 17:15:33 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:01 GMT
+      Last-Modified:
+      - Fri, 24 Apr 2026 17:15:33 GMT
+      Server:
+      - nginx/1.28.0
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      erddap-server:
+      - 2.30.0
+      xdods-server:
+      - dods/3.7
+    status:
+      code: 200
+      message: ''
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Host:
+      - standards.sensors.ioos.us
+      User-Agent:
+      - python-httpx/0.28.1
+    method: HEAD
     uri: https://standards.sensors.ioos.us/erddap/tabledap/org_cormp_cap2.htmlTable?station,z&distinct()
   response:
     body:
@@ -53,11 +125,11 @@ interactions:
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Thu, 12 Mar 2026 12:16:03 GMT
+      - Fri, 24 Apr 2026 17:15:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:01 GMT
       Last-Modified:
-      - Thu, 12 Mar 2026 12:16:03 GMT
+      - Fri, 24 Apr 2026 17:15:35 GMT
       Server:
       - nginx/1.28.0
       Strict-Transport-Security:
@@ -65,7 +137,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       erddap-server:
-      - 2.28.1
+      - 2.30.0
       xdods-server:
       - dods/3.7
     status:


### PR DESCRIPTION
This function is used by developers to quickly check if a built URL is valid or not without fetching the whole thing. Caching it doesn't make sense b/c people to want it do fail if the response changed.