### PR TITLE
Drop pytz

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -6,14 +6,10 @@ import copy
 import functools
 import io
 from collections import OrderedDict
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from datetime import datetime
+from datetime import datetime
 from typing import BinaryIO
 from urllib import parse
 
-import pytz
 import requests
 from pandas import to_datetime
 
@@ -222,10 +218,11 @@ def parse_dates(
     else:
         parse_date_time = date_time
 
+    # Naive datetimes tzinfo must be replaced, tz-aware should be converted.
     if not parse_date_time.tzinfo:
-        parse_date_time = pytz.utc.localize(parse_date_time)
+        parse_date_time = parse_date_time.replace(tzinfo=datetime.UTC)
     else:
-        parse_date_time = parse_date_time.astimezone(pytz.utc)
+        parse_date_time = parse_date_time.astimezone(datetime.UTC)
 
     return parse_date_time.timestamp()
 

--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import copy
+import datetime
 import functools
 import io
 from collections import OrderedDict
-from datetime import datetime
 from typing import BinaryIO
 from urllib import parse
 
@@ -197,7 +197,7 @@ def _is_quoted(url: str) -> bool:
 
 
 def parse_dates(
-    date_time: datetime | str,
+    date_time: datetime.datetime | str,
     *,
     dayfirst: OptionalBool = False,
     yearfirst: OptionalBool = False,
@@ -303,7 +303,7 @@ def get_search_url(  # noqa: PLR0913
         search_for = parse.quote_plus(search_for)
         base += "&searchFor={searchFor}"
 
-    # Convert dates from datetime to `seconds since 1970-01-01T00:00:00Z`.
+    # Convert dates from datetime.datetime to secs since 1970-01-01T00:00:00Z.
     min_time = kwargs.pop("min_time", "")
     max_time = kwargs.pop("max_time", "")
     if min_time and not _check_substrings(min_time):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,6 @@ nbsphinx
 netcdf4
 pendulum>=2.0.1
 pooch
-pre-commit
 pytest
 pytest-cov
 pytest-recording
@@ -21,7 +20,6 @@ scitools-iris>=3.3.0
 setuptools_scm
 sphinx
 twine
-types-pytz
 types-requests
 wheel
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas>=0.25.2,<4
-pytz
 requests

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import datetime
-import sys
 from zoneinfo import ZoneInfo
 
-import packaging.version
 import pytest
 
 from erddapy.core.griddap import (
@@ -18,13 +16,6 @@ from erddapy.core.url import (
     _quote_string_constraints,
     parse_dates,
 )
-
-if packaging.version.parse(
-    f"{sys.version_info.major}.{sys.version_info.minor}",
-) < packaging.version.parse(
-    "3.11",
-):
-    datetime.UTC = datetime.timezone.utc
 
 
 def test_parse_dates_utc_datetime():

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -1,11 +1,13 @@
 """Test ERDDAP functionality."""
 
+from __future__ import annotations
+
 import datetime
 import sys
+from zoneinfo import ZoneInfo
 
 import packaging.version
 import pytest
-import pytz
 
 from erddapy.core.griddap import (
     _griddap_check_constraints,
@@ -27,13 +29,13 @@ if packaging.version.parse(
 
 def test_parse_dates_utc_datetime():
     """UTC timestamp at 1970-1-1 must be 0."""
-    d = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)
+    d = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.UTC)
     assert parse_dates(d) == 0
 
 
 def test_parse_dates_nonutc_datetime():
     """Non-UTC timestamp at 1970-1-1 must have the zone offset."""
-    d = datetime.datetime(1970, 1, 1, tzinfo=pytz.timezone("US/Eastern"))
+    d = datetime.datetime(1970, 1, 1, tzinfo=ZoneInfo("US/Eastern"))
     assert parse_dates(d) == abs(d.utcoffset().total_seconds())
 
 


### PR DESCRIPTION
Both `zoneinfo` (py39) and `datetime.UTC` (py311) will be available when we drop py310 (upcoming PR). Let's keep this here for now.