### PR TITLE
Fix relative-constraint false positives leaving ordinary string values unquoted (#477)

### DIFF
--- a/erddapy/core/url.py
+++ b/erddapy/core/url.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import functools
 import io
+import re
 from collections import OrderedDict
 from typing import Any, BinaryIO
 from urllib import parse
@@ -180,10 +181,22 @@ def _format_constraints_url(kwargs: dict) -> str:
 
 
 def _check_substrings(constraint: str) -> bool:
-    """Extend the OPeNDAP with extra strings."""
-    substrings = ["now", "min", "max"]
+    """Return True if the constraint is a relative (server-side) expression.
+
+    ERDDAP relative constraints are "now", optionally followed by an offset,
+    like "now-7days", or "min(varName)"/"max(varName)", optionally followed
+    by an offset, like "max(time)-1day". Those must not be quoted nor parsed
+    as dates. See
+    https://erddap.ioos.us/erddap/tabledap/documentation.html#constraints
+
+    """
+    relative_expressions = (
+        r"^now([+-].+)?$",
+        r"^(min|max)\(.+\)([+-].+)?$",
+    )
+    value = str(constraint)
     return any(
-        True for substring in substrings if substring in str(constraint)
+        re.match(expression, value) for expression in relative_expressions
     )
 
 

--- a/tests/test_erddapy.py
+++ b/tests/test_erddapy.py
@@ -67,6 +67,39 @@ def test__quote_string_constraints():
             assert value.endswith('"')
 
 
+def test__quote_string_constraints_substring_false_positives():
+    """Plain values that merely contain now/min/max must still be quoted."""
+    kw = _quote_string_constraints(
+        {
+            "station=": "terminal_1",
+            "station!=": "snowfall_stn",
+            "station<": "maximum_buoy",
+            "station>": "minas_basin",
+            "cdm_data_type": "Maximum",
+            "station=~": "(WMO.*|.*minute.*)",
+        },
+    )
+
+    for value in kw.values():
+        assert value.startswith('"')
+        assert value.endswith('"')
+
+
+def test__quote_string_constraints_relative_constraints():
+    """Relative constraints like now-7days must not be quoted."""
+    kw = _quote_string_constraints(
+        {
+            "time>": "now-7days",
+            "depth>": "min(depth)",
+            "time<": "max(time)-1day",
+        },
+    )
+
+    for value in kw.values():
+        assert not value.startswith('"')
+        assert not value.endswith('"')
+
+
 def test__format_constraints_url():
     """Test constraint formatting."""
     kw_url = _format_constraints_url(

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -230,6 +230,35 @@ def test_download_url_relative_constraints(e):
     assert options["longitude<"] == max_lon
 
 
+def test_download_url_quotes_substring_false_positives(e):
+    """Test that values containing now/min/max substrings get quoted."""
+    dataset_id = "org_cormp_cap2"
+    variables = ["station", "z"]
+
+    stations = [
+        "terminal_1",
+        "snowfall_stn",
+        "maximum_buoy",
+        "minas_basin",
+    ]
+    for station in stations:
+        url = e.get_download_url(
+            dataset_id=dataset_id,
+            variables=variables,
+            response="csv",
+            constraints={"station=": station},
+        )
+        assert url.endswith(f'&station="{station}"')
+
+    url = e.get_download_url(
+        dataset_id=dataset_id,
+        variables=variables,
+        response="csv",
+        constraints={"station=~": "(WMO.*|.*minute.*)"},
+    )
+    assert url.endswith('&station=~"(WMO.*|.*minute.*)"')
+
+
 @pytest.mark.web
 @pytest.mark.vcr
 def test_get_var_by_attr(e):


### PR DESCRIPTION
# Fix relative-constraint false positives in `_check_substrings`

## Summary

String constraint values that merely contain the letters `now`, `min`, or `max` (e.g. `station="terminal_1"`, `cdm_data_type="Maximum"`, or a regex constraint containing the word `minute`) were misclassified as ERDDAP relative (server-side) expressions and silently left unquoted. ERDDAP then rejects the query with HTTP 400: *"For constraints of String variables, the right-hand-side value must be surrounded by double quotes"* — the exact error the original quoting feature (#18) was added to prevent. This PR replaces the bare substring containment test with anchored patterns that follow the actual ERDDAP relative-constraint grammar.

Fixes #477

## Root cause

`_check_substrings` in `erddapy/core/url.py` decided a value was a relative expression via `substring in str(constraint)` over `["now", "min", "max"]`, so any ordinary value containing those letters anywhere was treated as relative and skipped both quoting and date parsing.

## What the fix changes

- `erddapy/core/url.py`: `_check_substrings` now matches the value against anchored patterns derived from the [ERDDAP tabledap constraint grammar](https://erddap.ioos.us/erddap/tabledap/documentation.html#constraints): `^now([+-].+)?$` (e.g. `now`, `now-7days`) and `^(min|max)\(.+\)([+-].+)?$` (e.g. `min(depth)`, `max(time)-1day`). Genuine relative constraints behave exactly as before; the existing relative-constraint tests (`test_download_url_relative_constraints`, `test_search_url_valid_request_with_relative_time_constraints`) are unchanged and still pass.
- `tests/test_erddapy.py`: adds `test__quote_string_constraints_substring_false_positives` (values `terminal_1`, `snowfall_stn`, `maximum_buoy`, `minas_basin`, `Maximum`, and a regex containing `minute` must all be quoted) and `test__quote_string_constraints_relative_constraints` (`now-7days`, `min(depth)`, `max(time)-1day` must not be quoted).
- `tests/test_url_builder.py`: adds `test_download_url_quotes_substring_false_positives`, an offline end-to-end check that `get_download_url` quotes such station values and regex constraints.

## Test evidence

Regression tests on the base branch (fix reverted):

```
FAILED tests/test_erddapy.py::test__quote_string_constraints_substring_false_positives
FAILED tests/test_url_builder.py::test_download_url_quotes_substring_false_positives
2 failed, 1 passed in 12.51s
```

with the failing assertion showing the malformed URL:

```
E           assert False
E            +  where False = ...endswith('&station="terminal_1"')
E            +    'https://standards.sensors.ioos.us/erddap/tabledap/org_cormp_cap2.csv?station,z&station=terminal_1'.endswith
```

With the fix applied, the offline suite (`pytest -m "not web" --ignore=tests/test_to_objects.py`, Windows 11 / Python 3.14):

```
18 passed, 24 deselected
```

(baseline on `main` before this PR: 15 passed, 24 deselected — the 3 new tests account for the difference; no existing test changed behavior). `test_to_objects.py` is excluded only because `iris` has no Python 3.14 wheel in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
