### PR TITLE
Fix get_var_by_attr never matching falsy attribute values (#478)

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -546,7 +546,7 @@ class ERDDAP:
                     has_value_flag = v(var.get(k, None))
                     if not has_value_flag:
                         break
-                elif var.get(k) and var.get(k) == v:
+                elif k in var and var[k] == v:
                     has_value_flag = True
                 else:
                     has_value_flag = False

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -259,6 +259,30 @@ def test_get_var_by_attr(e):
     ]
 
 
+def test_get_var_by_attr_falsy_attribute_values(e, monkeypatch):
+    """Test that get_var_by_attr can match falsy values like 0 and ""."""
+    datasets = {
+        "fake_dataset": {
+            "salt": {"valid_min": 0, "comment": ""},
+            "temp": {"valid_min": 2.5, "comment": "in-situ"},
+        },
+    }
+
+    def _get_variables(dataset_id):
+        return datasets[dataset_id]
+
+    monkeypatch.setattr(e, "_get_variables", _get_variables)
+
+    matches = e.get_var_by_attr(dataset_id="fake_dataset", valid_min=0)
+    assert matches == ["salt"]
+
+    matches = e.get_var_by_attr(dataset_id="fake_dataset", comment="")
+    assert matches == ["salt"]
+
+    matches = e.get_var_by_attr(dataset_id="fake_dataset", valid_min=2.5)
+    assert matches == ["temp"]
+
+
 @pytest.mark.web
 @pytest.mark.vcr
 def test_download_url_distinct(e):


### PR DESCRIPTION
# Fix `get_var_by_attr` never matching falsy attribute values

## Summary

`ERDDAP.get_var_by_attr` could never match a variable whose attribute value is falsy — e.g. `valid_min=0`, `valid_min=0.0`, or an empty-string `comment` — even when the requested value compared equal. The method is documented as mirroring netCDF4-python's `get_variables_by_attributes`, which matches these values fine.

Fixes #478

## Root cause

The matching branch in `erddapy/erddapy.py` read `elif var.get(k) and var.get(k) == v:` — the leading `var.get(k)` truthiness guard short-circuits to `False` for any falsy attribute value before the equality test runs.

## What the fix changes

- `erddapy/erddapy.py`: the branch becomes `elif k in var and var[k] == v:` — a presence check plus plain equality, so falsy values match while a genuinely absent attribute still does not (including searching for `v=None`).
- `tests/test_url_builder.py`: adds `test_get_var_by_attr_falsy_attribute_values`, an offline test that stubs `_get_variables` with a fake dataset and asserts `valid_min=0` and `comment=""` match the right variable (and a truthy value still matches as before).

## Test evidence

Regression test on the base branch (fix reverted):

```
>       assert matches == ["salt"]
E       AssertionError: assert [] == ['salt']
FAILED tests/test_url_builder.py::test_get_var_by_attr_falsy_attribute_values
1 failed in 10.90s
```

With the fix applied, the offline suite (`pytest -m "not web" --ignore=tests/test_to_objects.py`, Windows 11 / Python 3.14):

```
16 passed, 24 deselected
```

(baseline on `main` before this PR: 15 passed, 24 deselected — the 1 new test accounts for the difference; no existing test changed behavior). `test_to_objects.py` is excluded only because `iris` has no Python 3.14 wheel in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
